### PR TITLE
Fix mx issues: #10, #11, #12, #13, #17

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -11,6 +11,9 @@ detectors:
     exclude:
       - Truemail::Validate::Smtp::Request#run
       - Truemail::Validate::Smtp#run
+      - Truemail::Validate::Mx#hosts_from_cname_records
+      - Truemail::Validate::Mx#mx_lookup
+      - Truemail::Configuration#initialize
 
   TooManyInstanceVariables:
     exclude:
@@ -19,11 +22,13 @@ detectors:
   Attribute:
     exclude:
       - Truemail::Configuration#smtp_safe_check
+      - Truemail::Validate::ResolverExecutionWrapper#attempts
 
   UtilityFunction:
     exclude:
       - Truemail::Validate::Smtp::Request#compose_from
       - Truemail::Validator#select_validation_type
+      - Truemail::Validate::Mx#mx_records
 
   ControlParameter:
     exclude:

--- a/.reek.yml
+++ b/.reek.yml
@@ -12,7 +12,6 @@ detectors:
       - Truemail::Validate::Smtp::Request#run
       - Truemail::Validate::Smtp#run
       - Truemail::Validate::Mx#hosts_from_cname_records
-      - Truemail::Validate::Mx#mx_lookup
       - Truemail::Configuration#initialize
 
   TooManyInstanceVariables:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ RSpec/ContextWording:
 
 RSpec/AnyInstance:
   Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (0.1.3)
+    truemail (0.1.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/truemail.rb
+++ b/lib/truemail.rb
@@ -32,5 +32,9 @@ module Truemail
       raise ConfigurationError, NOT_CONFIGURED unless configuration
       Truemail::Validator.new(email, **options).run
     end
+
+    def valid?(email, **options)
+      validate(email, **options).result.valid?
+    end
   end
 end

--- a/lib/truemail/configuration.rb
+++ b/lib/truemail/configuration.rb
@@ -4,20 +4,23 @@ module Truemail
   class Configuration
     DEFAULT_CONNECTION_TIMEOUT = 2
     DEFAULT_RESPONSE_TIMEOUT = 2
+    DEFAULT_RETRY_COUNT = 1
 
     attr_reader :email_pattern,
                 :verifier_email,
                 :verifier_domain,
                 :connection_timeout,
                 :response_timeout,
+                :retry_count,
                 :validation_type_by_domain
 
     attr_accessor :smtp_safe_check
 
     def initialize
       @email_pattern = Truemail::RegexConstant::REGEX_EMAIL_PATTERN
-      @connection_timeout = DEFAULT_CONNECTION_TIMEOUT
-      @response_timeout = DEFAULT_RESPONSE_TIMEOUT
+      @connection_timeout = Truemail::Configuration::DEFAULT_CONNECTION_TIMEOUT
+      @response_timeout = Truemail::Configuration::DEFAULT_RESPONSE_TIMEOUT
+      @retry_count = Truemail::Configuration::DEFAULT_RETRY_COUNT
       @validation_type_by_domain = {}
       @smtp_safe_check = false
     end
@@ -38,7 +41,7 @@ module Truemail
       @verifier_domain = domain.downcase
     end
 
-    %i[connection_timeout response_timeout].each do |method|
+    %i[connection_timeout response_timeout retry_count].each do |method|
       define_method("#{method}=") do |argument|
         raise ArgumentError.new(argument, __method__) unless argument.is_a?(Integer) && argument.positive?
         instance_variable_set(:"@#{method}", argument)

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -19,6 +19,7 @@ module Truemail
   module Validate
     require 'truemail/validate/base'
     require 'truemail/validate/regex'
+    require 'truemail/validate/resolver_execution_wrapper'
     require 'truemail/validate/mx'
     require 'truemail/validate/smtp'
     require 'truemail/validate/smtp/response'

--- a/lib/truemail/validate/mx.rb
+++ b/lib/truemail/validate/mx.rb
@@ -5,21 +5,62 @@ module Truemail
     class Mx < Truemail::Validate::Base
       require 'resolv'
 
-      ERROR = 'mx records not found'
+      ERROR = 'target host(s) not found'
 
       def run
         return false unless Truemail::Validate::Regex.check(result)
         result.domain = result.email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1]
-        return true if success(!result.mail_servers.push(*mx_records).empty?)
+        return true if success(mx_lookup)
         add_error(Truemail::Validate::Mx::ERROR)
         false
       end
 
       private
 
-      def mx_records
-        mx_records = Resolv::DNS.open { |dns| dns.getresources(result.domain, Resolv::DNS::Resource::IN::MX) }
-        mx_records.sort_by(&:preference).map { |mx_record| mx_record.exchange.to_s }
+      def host_extractor_methods
+        %i[hosts_from_mx_records? hosts_from_cname_records? host_from_a_record?]
+      end
+
+      def mx_lookup
+        host_extractor_methods.any? do |method|
+          Truemail::Validate::ResolverExecutionWrapper.call { send(method) }
+        end
+      end
+
+      def fetch_target_hosts(hosts)
+        result.mail_servers.push(*hosts)
+      end
+
+      def mx_records(domain)
+        Resolv::DNS.new.getresources(domain, Resolv::DNS::Resource::IN::MX).sort_by(&:preference).map do |mx_record|
+          Resolv.getaddress(mx_record.exchange.to_s)
+        end
+      end
+
+      def mail_servers_found?
+        !result.mail_servers.empty?
+      end
+
+      def hosts_from_mx_records?
+        fetch_target_hosts(mx_records(result.domain))
+        mail_servers_found?
+      end
+
+      def hosts_from_cname_records?
+        cname_records = Resolv::DNS.new.getresources(result.domain, Resolv::DNS::Resource::IN::CNAME)
+        return if cname_records.empty?
+        cname_records.each do |cname_record|
+          host = Resolv.getaddress(cname_record.name.to_s)
+          hostname = Resolv.getname(host)
+          found_hosts = mx_records(hostname)
+          fetch_target_hosts(found_hosts.empty? ? [host] : found_hosts)
+        end
+        mail_servers_found?
+      end
+
+      def host_from_a_record?
+        fetch_target_hosts([Resolv.getaddress(result.domain)])
+        mail_servers_found?
       end
     end
   end

--- a/lib/truemail/validate/resolver_execution_wrapper.rb
+++ b/lib/truemail/validate/resolver_execution_wrapper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Truemail
+  module Validate
+    class ResolverExecutionWrapper
+      attr_accessor :attempts
+
+      def self.call(&block)
+        new.call(&block)
+      end
+
+      def initialize
+        @attempts = Truemail.configuration.retry_count
+      end
+
+      def call(&block)
+        Timeout.timeout(Truemail.configuration.connection_timeout, &block)
+      rescue Resolv::ResolvError
+        false
+      rescue Timeout::Error
+        retry unless (self.attempts -= 1).zero?
+        false
+      end
+    end
+  end
+end

--- a/lib/truemail/validate/smtp.rb
+++ b/lib/truemail/validate/smtp.rb
@@ -18,7 +18,7 @@ module Truemail
         establish_smtp_connection
         return true if success(success_response?)
         result.smtp_debug = smtp_results
-        return true if success(not_includes_user_not_found_errors)
+        return true if success(not_includes_user_not_found_errors?)
         add_error(Truemail::Validate::Smtp::ERROR)
         false
       end
@@ -45,7 +45,7 @@ module Truemail
         smtp_results.map(&:response).any?(&:rcptto)
       end
 
-      def not_includes_user_not_found_errors
+      def not_includes_user_not_found_errors?
         return unless Truemail.configuration.smtp_safe_check
         result.smtp_debug.map(&:response).map(&:errors).all? do |errors|
           next true unless errors.key?(:rcptto)

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/support/objects/cname_records.yml
+++ b/spec/support/objects/cname_records.yml
@@ -1,0 +1,15 @@
+---
+- !ruby/object:Resolv::DNS::Resource::IN::CNAME
+  name: !ruby/object:Resolv::DNS::Name
+    labels:
+    - !ruby/object:Resolv::DNS::Label::Str
+      string: ghs
+      downcase: ghs
+    - !ruby/object:Resolv::DNS::Label::Str
+      string: googlehosted
+      downcase: googlehosted
+    - !ruby/object:Resolv::DNS::Label::Str
+      string: com
+      downcase: com
+    absolute: true
+  ttl: 120

--- a/spec/support/shared_examples/has_attr_accessor.rb
+++ b/spec/support/shared_examples/has_attr_accessor.rb
@@ -8,6 +8,7 @@ module Truemail
       verifier_domain
       connection_timeout
       response_timeout
+      retry_count
       smtp_safe_check
     ].each do |attribute|
       it "has attr_accessor :#{attribute}" do

--- a/spec/support/shared_examples/sets_default_configuration.rb
+++ b/spec/support/shared_examples/sets_default_configuration.rb
@@ -8,6 +8,7 @@ module Truemail
       expect(configuration_instance.verifier_domain).to be_nil
       expect(configuration_instance.connection_timeout).to eq(Truemail::Configuration::DEFAULT_CONNECTION_TIMEOUT)
       expect(configuration_instance.response_timeout).to eq(Truemail::Configuration::DEFAULT_RESPONSE_TIMEOUT)
+      expect(configuration_instance.retry_count).to eq(Truemail::Configuration::DEFAULT_RETRY_COUNT)
       expect(configuration_instance.validation_type_by_domain).to eq({})
       expect(configuration_instance.smtp_safe_check).to be(false)
     end

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Truemail::Configuration do
   describe 'defined constants' do
     specify { expect(described_class).to be_const_defined(:DEFAULT_CONNECTION_TIMEOUT) }
     specify { expect(described_class).to be_const_defined(:DEFAULT_RESPONSE_TIMEOUT) }
+    specify { expect(described_class).to be_const_defined(:DEFAULT_RETRY_COUNT) }
   end
 
   describe '.new' do
@@ -31,6 +32,7 @@ RSpec.describe Truemail::Configuration do
         expect(configuration_instance.email_pattern).to eq(Truemail::RegexConstant::REGEX_EMAIL_PATTERN)
         expect(configuration_instance.connection_timeout).to eq(2)
         expect(configuration_instance.response_timeout).to eq(2)
+        expect(configuration_instance.retry_count).to eq(1)
         expect(configuration_instance.validation_type_by_domain).to eq({})
         expect(configuration_instance.smtp_safe_check).to be(false)
       end
@@ -178,6 +180,22 @@ RSpec.describe Truemail::Configuration do
             expect { configuration_instance.response_timeout = 5 }
               .to change(configuration_instance, :response_timeout)
               .from(2).to(5)
+          end
+        end
+
+        context 'with invalid response timeout' do
+          let(:setter) { :response_timeout= }
+
+          include_examples 'raises argument error'
+        end
+      end
+
+      describe '#retry_count=' do
+        context 'with valid retry count' do
+          it 'sets custom retry count' do
+            expect { configuration_instance.retry_count = 2 }
+              .to change(configuration_instance, :retry_count)
+              .from(1).to(2)
           end
         end
 

--- a/spec/truemail/validate/mx_spec.rb
+++ b/spec/truemail/validate/mx_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Truemail::Validate::Mx do
+  let(:email) { FFaker::Internet.email }
+  let(:result_instance) { Truemail::Validator::Result.new(email: email) }
+
+  before { Truemail.configure { |config| config.verifier_email = email } }
+
   describe 'defined constants' do
     specify { expect(described_class).to be_const_defined(:ERROR) }
   end
@@ -8,39 +13,134 @@ RSpec.describe Truemail::Validate::Mx do
   describe '.check' do
     subject(:mx_validator) { described_class.check(result_instance) }
 
-    let(:email) { FFaker::Internet.email }
-    let(:result_instance) { Truemail::Validator::Result.new(email: email) }
-    let(:mx_records_object) { YAML.load(File.open(mx_records_file, 'r')) }
+    let(:mx_validator_instance) { instance_double(described_class, run: true) }
+
+    it 'receive #run' do
+      allow(Truemail::Validate::Regex).to receive(:check).and_return(true)
+      allow(described_class).to receive(:new).and_return(mx_validator_instance)
+      expect(mx_validator_instance).to receive(:run)
+      expect(mx_validator).to be(true)
+    end
+  end
+
+  describe '#run' do
+    subject(:mx_validator) { mx_validator_instance.run }
+
+    let(:mx_validator_instance) { described_class.new(result_instance) }
 
     context 'when validation pass' do
-      let(:mx_records_file) { "#{File.expand_path('../../', __dir__)}/support/objects/mx_records.yml" }
-      let(:mail_servers_sorted_by_preference) do
-        [
-          'gmail-smtp-in.l.google.com',
-          'alt1.gmail-smtp-in.l.google.com',
-          'alt2.gmail-smtp-in.l.google.com',
-          'alt3.gmail-smtp-in.l.google.com',
-          'alt4.gmail-smtp-in.l.google.com'
-        ]
-      end
+      let(:host_address) { FFaker::Internet.ip_v4_address }
+      let(:host_name) { FFaker::Internet.domain_name }
+      let(:mail_servers_by_ip) { Array.new(5) { host_address } }
+      let(:mx_records_object) { YAML.load(File.open(mx_records_file, 'r')) }
 
       before do
         allow(Truemail::Validate::Regex).to receive(:check).and_return(true)
-        allow(Resolv::DNS).to receive(:open).and_return(mx_records_object)
         result_instance.success = true
       end
 
-      specify do
-        expect { mx_validator }
-          .to change(result_instance, :domain)
-          .from(nil).to(email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3])
-          .and change(result_instance, :mail_servers)
-          .from([]).to(mail_servers_sorted_by_preference)
-          .and not_change(result_instance, :success)
+      context 'when mx records found' do
+        let(:mx_records_file) { "#{File.expand_path('../../', __dir__)}/support/objects/mx_records.yml" }
+
+        before do
+          allow(Resolv::DNS).to receive_message_chain(:new, :getresources).and_return(mx_records_object)
+          allow(Resolv).to receive(:getaddress).and_return(host_address)
+        end
+
+        specify do
+          expect(mx_validator_instance).to receive(:hosts_from_mx_records?).and_call_original
+          expect(mx_validator_instance).not_to receive(:hosts_from_cname_records?)
+          expect(mx_validator_instance).not_to receive(:host_from_a_record?)
+
+          expect { mx_validator }
+            .to change(result_instance, :domain)
+            .from(nil).to(email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3])
+            .and change(result_instance, :mail_servers)
+            .from([]).to(mail_servers_by_ip)
+            .and not_change(result_instance, :success)
+        end
+
+        it 'returns true' do
+          expect(mx_validator).to be(true)
+        end
       end
 
-      it 'returns true' do
-        expect(mx_validator).to be(true)
+      context 'when cname records found' do
+        let(:cname_records_file) { "#{File.expand_path('../../', __dir__)}/support/objects/cname_records.yml" }
+        let(:cname_records_object) { YAML.load(File.open(cname_records_file, 'r')) }
+
+        before do
+          allow(mx_validator_instance).to receive(:hosts_from_mx_records?)
+          allow(Resolv).to receive(:getname).and_return(host_name)
+          allow(Resolv).to receive(:getaddress).and_return(host_address)
+        end
+
+        context 'when mx records found' do
+          before do
+            allow(Resolv::DNS).to receive_message_chain(:new, :getresources).and_return(cname_records_object)
+            allow(mx_validator_instance).to receive(:mx_records).and_return(mail_servers_by_ip)
+          end
+
+          specify do
+            expect(mx_validator_instance).to receive(:hosts_from_cname_records?).and_call_original
+            expect(mx_validator_instance).not_to receive(:host_from_a_record?)
+
+            expect { mx_validator }
+              .to change(result_instance, :domain)
+              .from(nil).to(email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3])
+              .and change(result_instance, :mail_servers)
+              .from([]).to(mail_servers_by_ip)
+              .and not_change(result_instance, :success)
+          end
+
+          it 'returns true' do
+            expect(mx_validator).to be(true)
+          end
+        end
+
+        context 'when mx records not found' do
+          before do
+            allow(Resolv::DNS).to receive_message_chain(:new, :getresources).and_return(cname_records_object)
+            allow(mx_validator_instance).to receive(:mx_records).and_return([])
+          end
+
+          specify do
+            expect(mx_validator_instance).to receive(:hosts_from_cname_records?).and_call_original
+            expect(mx_validator_instance).not_to receive(:host_from_a_record?)
+
+            expect { mx_validator }
+              .to change(result_instance, :domain)
+              .from(nil).to(email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3])
+              .and change(result_instance, :mail_servers)
+              .from([]).to([host_address])
+              .and not_change(result_instance, :success)
+          end
+
+          it 'returns true' do
+            expect(mx_validator).to be(true)
+          end
+        end
+      end
+
+      context 'when a record found' do
+        before do
+          allow(mx_validator_instance).to receive(:hosts_from_mx_records?)
+          allow(mx_validator_instance).to receive(:hosts_from_cname_records?)
+          allow(Resolv).to receive(:getaddress).and_return(host_address)
+        end
+
+        specify do
+          expect { mx_validator }
+            .to change(result_instance, :domain)
+            .from(nil).to(email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3])
+            .and change(result_instance, :mail_servers)
+            .from([]).to([host_address])
+            .and not_change(result_instance, :success)
+        end
+
+        it 'returns true' do
+          expect(mx_validator).to be(true)
+        end
       end
     end
 
@@ -49,7 +149,9 @@ RSpec.describe Truemail::Validate::Mx do
         before do
           allow(Truemail::Validate::Regex).to receive(:check).and_return(true)
           result_instance.success = true
-          allow(Resolv::DNS).to receive(:open).and_return([])
+          allow(mx_validator_instance).to receive(:hosts_from_mx_records?)
+          allow(mx_validator_instance).to receive(:hosts_from_cname_records?)
+          allow(mx_validator_instance).to receive(:host_from_a_record?)
         end
 
         specify do

--- a/spec/truemail/validate/resolver_execution_wrapper_spec.rb
+++ b/spec/truemail/validate/resolver_execution_wrapper_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Truemail::Validate::ResolverExecutionWrapper do
+  let(:email) { FFaker::Internet.email }
+  let(:method) { :hosts_from_mx_records? }
+  let(:mx_instance) { instance_double(Truemail::Validate::Mx, method => true) }
+  let(:block) { ->(_) { mx_instance.send(method) } }
+
+  before { Truemail.configure { |config| config.verifier_email = email } }
+
+  describe '.call' do
+    subject(:resolver_execution_wrapper) { resolver_execution_wrapper_instance.call(&block) }
+
+    let(:resolver_execution_wrapper_instance) { described_class.new }
+
+    before { allow(resolver_execution_wrapper_instance).to receive(:call).and_call_original }
+
+    context 'when not raises exception' do
+      specify do
+        allow(mx_instance).to receive(method).and_return(true)
+        expect(resolver_execution_wrapper).to be(true)
+      end
+
+      specify do
+        allow(mx_instance).to receive(method).and_return(false)
+        expect(resolver_execution_wrapper).to be(false)
+      end
+    end
+
+    context 'when raises exception' do
+      context 'with Resolv::ResolvError exception' do
+        specify do
+          allow(mx_instance).to receive(method).and_raise(Resolv::ResolvError)
+          expect(resolver_execution_wrapper).to be(false)
+        end
+      end
+
+      context 'with Timeout::Error exception' do
+        specify do
+          allow(mx_instance).to receive(method).and_raise(Timeout::Error)
+
+          expect { resolver_execution_wrapper }
+            .to change(resolver_execution_wrapper_instance, :attempts).from(1).to(0)
+
+          expect(resolver_execution_wrapper).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/truemail_spec.rb
+++ b/spec/truemail_spec.rb
@@ -118,17 +118,31 @@ RSpec.describe Truemail do
           .to be_an_instance_of(Truemail::Validator)
       end
 
-      context 'when checks real email' do
-        specify do
-          expect(described_class.validate('vladyslav.trotsenko@rubygarage.org').result.valid?).to be(true)
+      describe 'integration tests' do
+        context 'when checks real email' do
+          specify do
+            expect(described_class.validate('vladyslav.trotsenko@rubygarage.org').result.valid?).to be(true)
+          end
         end
-      end
 
-      context 'when checks fake email' do
-        specify do
-          expect(described_class.validate('nonexistent_email@rubygarage.org').result.valid?).to be(false)
+        context 'when checks fake email' do
+          specify do
+            expect(described_class.validate('nonexistent_email@rubygarage.org').result.valid?).to be(false)
+          end
         end
       end
+    end
+  end
+
+  describe '.valid?' do
+    subject(:valid_helper) { described_class.valid?(email) }
+
+    before { described_class.configure { |config| config.verifier_email = email } }
+
+    it 'returns boolean from result instance' do
+      allow(Truemail::Validate::Smtp).to receive(:check).and_return(true)
+      allow_any_instance_of(Truemail::Validator::Result).to receive(:valid?).and_return(true)
+      expect(valid_helper).to be(true)
     end
   end
 end


### PR DESCRIPTION
Fixed MX gem logic with RFC 5321: https://tools.ietf.org/html/rfc5321#section-5

- [x] Added checking A record presence if ```MX``` and ```CNAME``` records not exist, https://github.com/rubygarage/truemail/issues/10
- [x] Added handling of ```CNAME``` records, https://github.com/rubygarage/truemail/issues/11
- [x] Added checking A record if ```MX``` and ```CNAME``` records not found, https://github.com/rubygarage/truemail/issues/12
- [x] Added supporting of multihomed MX records, conversion host names to ips, https://github.com/rubygarage/truemail/issues/17
- [x] Timeout configuration for DNS resolver, https://github.com/rubygarage/truemail/issues/13
- [x] Added ```.valid?``` helper
- [x] Updated gem version