### PR TITLE
Feature/skip validation by domain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (0.1.11)
+    truemail (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (0.1.10)
+    truemail (0.1.11)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Truemail gem helps you validate emails by regex pattern, presence of domain 
 
 - Configurable validator, validate only what you need
 - Zero runtime dependencies
+- Has simple SMTP debugger
 - 100% test coverage
 
 ## Installation
@@ -76,7 +77,7 @@ Truemail.configure do |config|
   # Also you can skip validation by domain. Available validation types: :regex, :mx, :smtp, :skip
   # This configuration will be used over current or default validation type parameter
   # All of validations for 'somedomain.com' will be processed with mx validation only
-  config.validation_type_for = { 'somedomain.com' => :mx }
+  config.validation_type_for = { 'somedomain.com' => :mx, 'otherdomain.com' => :skip }
 
   # Optional parameter. This option will be parse bodies of SMTP errors. It will be helpful
   # if SMTP server does not return an exact answer that the email does not exist

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Truemail.configure do |config|
   config.connection_attempts = 3
 
   # Optional parameter. You can predefine which type of validation will be used for domains.
-  # Available validation types: :regex, :mx, :smtp
+  # Also you can skip validation by domain. Available validation types: :regex, :mx, :smtp, :skip
   # This configuration will be used over current or default validation type parameter
   # All of validations for 'somedomain.com' will be processed with mx validation only
   config.validation_type_for = { 'somedomain.com' => :mx }

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -30,6 +30,7 @@ module Truemail
   end
 
   module Validate
+    require 'truemail/validate/skip'
     require 'truemail/validate/base'
     require 'truemail/validate/regex'
     require 'truemail/validate/mx'

--- a/lib/truemail/validate/skip.rb
+++ b/lib/truemail/validate/skip.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Truemail
+  module Validate
+    class Skip < Truemail::Worker
+      def run
+        success(true)
+      end
+    end
+  end
+end

--- a/lib/truemail/validator.rb
+++ b/lib/truemail/validator.rb
@@ -3,7 +3,7 @@
 module Truemail
   class Validator
     RESULT_ATTRS = %i[success email domain mail_servers errors smtp_debug].freeze
-    VALIDATION_TYPES = %i[regex mx smtp].freeze
+    VALIDATION_TYPES = %i[regex mx smtp skip].freeze
 
     Result = Struct.new(*RESULT_ATTRS, keyword_init: true) do
       def initialize(errors: {}, mail_servers: [], **args)

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '0.1.11'
+  VERSION = '0.2.0'
 end

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -229,13 +229,14 @@ RSpec.describe Truemail::Configuration do
 
       describe '#validation_type_for=' do
         context 'with valid validation type attributes' do
-          let(:domain_1) { FFaker::Internet.domain_name }
-          let(:domain_2) { FFaker::Internet.domain_name }
+          let(:domains_config) do
+            (1..4).map { FFaker::Internet.unique.domain_name }.zip(%i[regex mx smtp skip]).to_h
+          end
 
           it 'sets validation type for domain' do
-            expect { configuration_instance.validation_type_for = { domain_1 => :mx, domain_2 => :regex } }
+            expect { configuration_instance.validation_type_for = domains_config }
               .to change(configuration_instance, :validation_type_by_domain)
-              .from({}).to({ domain_1 => :mx, domain_2 => :regex  })
+              .from({}).to(domains_config)
           end
         end
 

--- a/spec/truemail/core_spec.rb
+++ b/spec/truemail/core_spec.rb
@@ -136,6 +136,7 @@ module Truemail
 
   RSpec.describe Truemail::Validate do
     describe 'defined constants' do
+      specify { expect(described_class).to be_const_defined(:Skip) }
       specify { expect(described_class).to be_const_defined(:Base) }
       specify { expect(described_class).to be_const_defined(:Regex) }
       specify { expect(described_class).to be_const_defined(:Mx) }

--- a/spec/truemail/validate/skip_spec.rb
+++ b/spec/truemail/validate/skip_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Truemail::Validate::Skip do
+  describe '.check' do
+    subject(:skip_validator) { described_class.check(result_instance) }
+
+    let(:result_instance) { Truemail::Validator::Result.new(email: FFaker::Internet.email) }
+
+    specify do
+      expect { skip_validator }.to change(result_instance, :success).from(nil).to(true)
+    end
+
+    it 'returns true' do
+      expect(skip_validator).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Implement skip validation by domain for validation_type_for configuration option:
```ruby
Truemail.configure do |config|
  config.validation_type_for = { 'somedomain.com' => :skip }
end
```
and
```ruby
Truemail.configuration.validation_type_for = { 'somedomain.com' => :skip }
```

- [x] Added new feature
- [x] Updated tests
- [x] Updated documentation
- [x] Updated wiki
- [x] Updated gem version