### PR TITLE
Feature/add result validation type marker to domain list match check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.0.0)
+    truemail (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/truemail/validator.rb
+++ b/lib/truemail/validator.rb
@@ -22,7 +22,7 @@ module Truemail
 
     def run
       Truemail::Validate::DomainListMatch.check(result)
-      Truemail::Validate.const_get(validation_type.capitalize).check(result) if result_not_changed?
+      result_not_changed? ? Truemail::Validate.const_get(validation_type.capitalize).check(result) : update_validation_type
       self
     end
 
@@ -30,6 +30,10 @@ module Truemail
 
     def result_not_changed?
       result.success.nil?
+    end
+
+    def update_validation_type
+      @validation_type = result.success ? :whitelist : :blacklist
     end
 
     def select_validation_type(email, current_validation_type)

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/truemail/validator_spec.rb
+++ b/spec/truemail/validator_spec.rb
@@ -64,14 +64,32 @@ module Truemail
           expect(Truemail::Validate::Regex).to receive(:check)
           expect(validator_instance_run).to be_an_instance_of(Truemail::Validator)
         end
+
+        specify do
+          expect { validator_instance_run }.not_to change(validator_instance, :validation_type)
+        end
       end
 
       context 'when email in the whitelist/blacklist' do
         let(:condition) { false }
 
-        it 'calls predefined validation class' do
+        it 'not calls predefined validation class' do
           expect(Truemail::Validate::Regex).not_to receive(:check)
           expect(validator_instance_run).to be_an_instance_of(Truemail::Validator)
+        end
+
+        context 'with whitelisted email' do
+          specify do
+            allow(validator_instance_result).to receive(:success).and_return(true)
+            expect { validator_instance_run }.to change(validator_instance, :validation_type).from(validation_type).to(:whitelist)
+          end
+        end
+
+        context 'with blacklisted email' do
+          specify do
+            allow(validator_instance_result).to receive(:success).and_return(false)
+            expect { validator_instance_run }.to change(validator_instance, :validation_type).from(validation_type).to(:blacklist)
+          end
         end
       end
     end


### PR DESCRIPTION
Implement result validation type marker for domain list match check.
```ruby
Truemail.validate('email@white-domain.com')

#<Truemail::Validator:0x000055b8429f3490
  @result=#<struct Truemail::Validator::Result
    success=true,
    email="email@white-domain.com",
    domain=nil,
    mail_servers=[],
    errors={},
    smtp_debug=nil>,
  @validation_type=:whitelist>

Truemail.validate('email@black-domain.com')

#<Truemail::Validator:0x000023y8429f3493
  @result=#<struct Truemail::Validator::Result
    success=false,
    email="email@black-domain.com",
    domain=nil,
    mail_servers=[],
    errors={},
    smtp_debug=nil>,
  @validation_type=:blacklist>
```
- [x] Added result validation type marker to domain list match check
- [x] Updated tests
- [x] Updated documentation
- [x] Updated wiki
- [x] Updated gem version