### PR TITLE
Feature/configurable default validation type, #48

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.0.1)
+    truemail (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Truemail.configure do |config|
   # there is one mx server).
   config.connection_attempts = 3
 
+  # Optional parameter. You can predefine default validation type for
+  # Truemail.validate('email@email.com') call without with-parameter
+  # Available validation types: :regex, :mx, :smtp
+  config.default_validation_type = :mx
+
   # Optional parameter. You can predefine which type of validation will be used for domains.
   # Also you can skip validation by domain. Available validation types: :regex, :mx, :smtp
   # This configuration will be used over current or default validation type parameter

--- a/lib/truemail/configuration.rb
+++ b/lib/truemail/configuration.rb
@@ -5,6 +5,7 @@ module Truemail
     DEFAULT_CONNECTION_TIMEOUT = 2
     DEFAULT_RESPONSE_TIMEOUT = 2
     DEFAULT_CONNECTION_ATTEMPTS = 2
+    DEFAULT_VALIDATION_TYPE = :smtp
 
     attr_reader :email_pattern,
                 :smtp_error_body_pattern,
@@ -13,6 +14,7 @@ module Truemail
                 :connection_timeout,
                 :response_timeout,
                 :connection_attempts,
+                :default_validation_type,
                 :validation_type_by_domain,
                 :whitelisted_domains,
                 :blacklisted_domains
@@ -27,6 +29,7 @@ module Truemail
       @connection_timeout = Truemail::Configuration::DEFAULT_CONNECTION_TIMEOUT
       @response_timeout = Truemail::Configuration::DEFAULT_RESPONSE_TIMEOUT
       @connection_attempts = Truemail::Configuration::DEFAULT_CONNECTION_ATTEMPTS
+      @default_validation_type = Truemail::Configuration::DEFAULT_VALIDATION_TYPE
       @validation_type_by_domain = {}
       @whitelisted_domains = []
       @blacklisted_domains = []
@@ -56,6 +59,11 @@ module Truemail
         raise_unless(argument, __method__, argument.is_a?(Integer) && argument.positive?)
         instance_variable_set(:"@#{method}", argument)
       end
+    end
+
+    def default_validation_type=(argument)
+      raise_unless(argument, __method__, argument.is_a?(Symbol) && Truemail::Validator::VALIDATION_TYPES.include?(argument))
+      @default_validation_type = argument
     end
 
     def validation_type_for=(settings)

--- a/lib/truemail/validator.rb
+++ b/lib/truemail/validator.rb
@@ -14,8 +14,8 @@ module Truemail
 
     attr_reader :validation_type, :result
 
-    def initialize(email, with: :smtp)
-      raise ArgumentError.new(with, :argument) unless VALIDATION_TYPES.include?(with)
+    def initialize(email, with: Truemail.configuration.default_validation_type)
+      raise Truemail::ArgumentError.new(with, :argument) unless Truemail::Validator::VALIDATION_TYPES.include?(with)
       @validation_type = select_validation_type(email, with)
       @result = Truemail::Validator::Result.new(email: email)
     end

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 end

--- a/spec/support/shared_examples/has_attr_accessor.rb
+++ b/spec/support/shared_examples/has_attr_accessor.rb
@@ -10,6 +10,7 @@ module Truemail
       connection_timeout
       response_timeout
       connection_attempts
+      default_validation_type
       whitelisted_domains
       blacklisted_domains
       smtp_safe_check

--- a/spec/support/shared_examples/sets_default_configuration.rb
+++ b/spec/support/shared_examples/sets_default_configuration.rb
@@ -10,6 +10,7 @@ module Truemail
       expect(configuration_instance.connection_timeout).to eq(Truemail::Configuration::DEFAULT_CONNECTION_TIMEOUT)
       expect(configuration_instance.response_timeout).to eq(Truemail::Configuration::DEFAULT_RESPONSE_TIMEOUT)
       expect(configuration_instance.connection_attempts).to eq(Truemail::Configuration::DEFAULT_CONNECTION_ATTEMPTS)
+      expect(configuration_instance.default_validation_type).to eq(Truemail::Configuration::DEFAULT_VALIDATION_TYPE)
       expect(configuration_instance.validation_type_by_domain).to eq({})
       expect(configuration_instance.whitelisted_domains).to eq([])
       expect(configuration_instance.blacklisted_domains).to eq([])

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Truemail::Configuration do
     specify { expect(described_class).to be_const_defined(:DEFAULT_CONNECTION_TIMEOUT) }
     specify { expect(described_class).to be_const_defined(:DEFAULT_RESPONSE_TIMEOUT) }
     specify { expect(described_class).to be_const_defined(:DEFAULT_CONNECTION_ATTEMPTS) }
+    specify { expect(described_class).to be_const_defined(:DEFAULT_VALIDATION_TYPE) }
   end
 
   describe '.new' do
@@ -34,6 +35,7 @@ RSpec.describe Truemail::Configuration do
         expect(configuration_instance.connection_timeout).to eq(2)
         expect(configuration_instance.response_timeout).to eq(2)
         expect(configuration_instance.connection_attempts).to eq(2)
+        expect(configuration_instance.default_validation_type).to eq(Truemail::Configuration::DEFAULT_VALIDATION_TYPE)
         expect(configuration_instance.validation_type_by_domain).to eq({})
         expect(configuration_instance.whitelisted_domains).to eq([])
         expect(configuration_instance.blacklisted_domains).to eq([])
@@ -52,6 +54,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :smtp_error_body_pattern)
           .and not_change(configuration_instance, :connection_timeout)
           .and not_change(configuration_instance, :response_timeout)
+          .and not_change(configuration_instance, :default_validation_type)
           .and not_change(configuration_instance, :validation_type_by_domain)
           .and not_change(configuration_instance, :whitelisted_domains)
           .and not_change(configuration_instance, :blacklisted_domains)
@@ -72,6 +75,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :smtp_error_body_pattern)
           .and not_change(configuration_instance, :connection_timeout)
           .and not_change(configuration_instance, :response_timeout)
+          .and not_change(configuration_instance, :default_validation_type)
           .and not_change(configuration_instance, :validation_type_by_domain)
           .and not_change(configuration_instance, :whitelisted_domains)
           .and not_change(configuration_instance, :blacklisted_domains)
@@ -92,6 +96,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :smtp_error_body_pattern)
           .and not_change(configuration_instance, :connection_timeout)
           .and not_change(configuration_instance, :response_timeout)
+          .and not_change(configuration_instance, :default_validation_type)
           .and not_change(configuration_instance, :validation_type_by_domain)
           .and not_change(configuration_instance, :whitelisted_domains)
           .and not_change(configuration_instance, :blacklisted_domains)
@@ -232,6 +237,41 @@ RSpec.describe Truemail::Configuration do
           let(:setter) { :connection_attempts= }
 
           include_examples 'raises argument error'
+        end
+      end
+
+      describe '#default_validation_type=' do
+        context 'with valid value' do
+          let(:valid_validation_type) { :mx }
+
+          it 'sets default validation type' do
+            expect { configuration_instance.default_validation_type = valid_validation_type }
+              .to change(configuration_instance, :default_validation_type)
+              .from(Truemail::Configuration::DEFAULT_VALIDATION_TYPE).to(valid_validation_type)
+          end
+        end
+
+        context 'with invalid value' do
+          shared_examples 'raises argument error' do
+            specify do
+              expect { configuration_instance.public_send(setter, invalid_validation_type) }
+                .to raise_error(Truemail::ArgumentError, "#{invalid_validation_type} is not a valid #{setter}")
+            end
+          end
+
+          let(:setter) { :default_validation_type= }
+
+          context 'when value in not symbol' do
+            let(:invalid_validation_type) { 'mx' }
+
+            include_examples 'raises argument error'
+          end
+
+          context 'when value has wrong validation type' do
+            let(:invalid_validation_type) { :not_valid_validation_type }
+
+            include_examples 'raises argument error'
+          end
         end
       end
 


### PR DESCRIPTION
Implement configurable default validation type.

You can predefine default validation type for ```Truemail.validate('email@email.com')``` call without with-parameter. Available validation types: ```:regex```, ```:mx```, ```:smtp```. By default validation type still be ```:smtp```

```ruby
Truemail.configure do |config|
  config.default_validation_type = :mx
end
```

- [x] Added configurable default validation type option, https://github.com/rubygarage/truemail/issues/48
- [x] Updated tests
- [x] Updated documentation
- [x] Updated wiki
- [x] Updated gem version