### PR TITLE
Feature/validation for whitelisted domains only

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -20,6 +20,7 @@ detectors:
 
   Attribute:
     exclude:
+      - Truemail::Configuration#whitelist_validation
       - Truemail::Configuration#smtp_safe_check
       - Truemail::Wrapper#attempts
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
 Metrics/LineLength:
   Max: 140
 
+Metrics/MethodLength:
+  Max: 15
+
 Metrics/CyclomaticComplexity:
   Enabled: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.1.0)
+    truemail (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/truemail/configuration.rb
+++ b/lib/truemail/configuration.rb
@@ -19,21 +19,14 @@ module Truemail
                 :whitelisted_domains,
                 :blacklisted_domains
 
-    attr_accessor :smtp_safe_check
+    attr_accessor :whitelist_validation, :smtp_safe_check
 
     alias retry_count connection_attempts
 
     def initialize
-      @email_pattern = Truemail::RegexConstant::REGEX_EMAIL_PATTERN
-      @smtp_error_body_pattern = Truemail::RegexConstant::REGEX_SMTP_ERROR_BODY_PATTERN
-      @connection_timeout = Truemail::Configuration::DEFAULT_CONNECTION_TIMEOUT
-      @response_timeout = Truemail::Configuration::DEFAULT_RESPONSE_TIMEOUT
-      @connection_attempts = Truemail::Configuration::DEFAULT_CONNECTION_ATTEMPTS
-      @default_validation_type = Truemail::Configuration::DEFAULT_VALIDATION_TYPE
-      @validation_type_by_domain = {}
-      @whitelisted_domains = []
-      @blacklisted_domains = []
-      @smtp_safe_check = false
+      instance_initializer.each do |instace_variable, value|
+        instance_variable_set(:"@#{instace_variable}", value)
+      end
     end
 
     %i[email_pattern smtp_error_body_pattern].each do |method|
@@ -83,6 +76,22 @@ module Truemail
     end
 
     private
+
+    def instance_initializer
+      {
+        email_pattern: Truemail::RegexConstant::REGEX_EMAIL_PATTERN,
+        smtp_error_body_pattern: Truemail::RegexConstant::REGEX_SMTP_ERROR_BODY_PATTERN,
+        connection_timeout: Truemail::Configuration::DEFAULT_CONNECTION_TIMEOUT,
+        response_timeout: Truemail::Configuration::DEFAULT_RESPONSE_TIMEOUT,
+        connection_attempts: Truemail::Configuration::DEFAULT_CONNECTION_ATTEMPTS,
+        default_validation_type: Truemail::Configuration::DEFAULT_VALIDATION_TYPE,
+        validation_type_by_domain: {},
+        whitelisted_domains: [],
+        whitelist_validation: false,
+        blacklisted_domains: [],
+        smtp_safe_check: false
+      }
+    end
 
     def raise_unless(argument_context, argument_name, condition)
       raise Truemail::ArgumentError.new(argument_context, argument_name) unless condition

--- a/lib/truemail/validate/domain_list_match.rb
+++ b/lib/truemail/validate/domain_list_match.rb
@@ -6,8 +6,8 @@ module Truemail
       ERROR = 'blacklisted email'
 
       def run
-        return success(true) if whitelisted_domain?
-        return unless blacklisted_domain?
+        return success(true) if whitelisted_domain? && !whitelist_validation?
+        return unless whitelist_validation_case? || blacklisted_domain?
         success(false)
         add_error(Truemail::Validate::DomainListMatch::ERROR)
       end
@@ -19,7 +19,15 @@ module Truemail
       end
 
       def whitelisted_domain?
-        configuration.whitelisted_domains.include?(email_domain)
+        @whitelisted_domain ||= configuration.whitelisted_domains.include?(email_domain)
+      end
+
+      def whitelist_validation?
+        configuration.whitelist_validation
+      end
+
+      def whitelist_validation_case?
+        whitelist_validation? && !whitelisted_domain?
       end
 
       def blacklisted_domain?

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/support/shared_examples/has_attr_accessor.rb
+++ b/spec/support/shared_examples/has_attr_accessor.rb
@@ -12,6 +12,7 @@ module Truemail
       connection_attempts
       default_validation_type
       whitelisted_domains
+      whitelist_validation
       blacklisted_domains
       smtp_safe_check
     ].each do |attribute|

--- a/spec/support/shared_examples/sets_default_configuration.rb
+++ b/spec/support/shared_examples/sets_default_configuration.rb
@@ -13,6 +13,7 @@ module Truemail
       expect(configuration_instance.default_validation_type).to eq(Truemail::Configuration::DEFAULT_VALIDATION_TYPE)
       expect(configuration_instance.validation_type_by_domain).to eq({})
       expect(configuration_instance.whitelisted_domains).to eq([])
+      expect(configuration_instance.whitelist_validation).to eq(false)
       expect(configuration_instance.blacklisted_domains).to eq([])
       expect(configuration_instance.smtp_safe_check).to be(false)
     end

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Truemail::Configuration do
         expect(configuration_instance.default_validation_type).to eq(Truemail::Configuration::DEFAULT_VALIDATION_TYPE)
         expect(configuration_instance.validation_type_by_domain).to eq({})
         expect(configuration_instance.whitelisted_domains).to eq([])
+        expect(configuration_instance.whitelist_validation).to eq(false)
         expect(configuration_instance.blacklisted_domains).to eq([])
         expect(configuration_instance.smtp_safe_check).to be(false)
       end
@@ -57,6 +58,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :default_validation_type)
           .and not_change(configuration_instance, :validation_type_by_domain)
           .and not_change(configuration_instance, :whitelisted_domains)
+          .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
           .and not_change(configuration_instance, :smtp_safe_check)
 
@@ -78,6 +80,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :default_validation_type)
           .and not_change(configuration_instance, :validation_type_by_domain)
           .and not_change(configuration_instance, :whitelisted_domains)
+          .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
           .and not_change(configuration_instance, :smtp_safe_check)
 
@@ -99,6 +102,7 @@ RSpec.describe Truemail::Configuration do
           .and not_change(configuration_instance, :default_validation_type)
           .and not_change(configuration_instance, :validation_type_by_domain)
           .and not_change(configuration_instance, :whitelisted_domains)
+          .and not_change(configuration_instance, :whitelist_validation)
           .and not_change(configuration_instance, :blacklisted_domains)
           .and not_change(configuration_instance, :smtp_safe_check)
 

--- a/spec/truemail/validate/domain_list_match_spec.rb
+++ b/spec/truemail/validate/domain_list_match_spec.rb
@@ -8,29 +8,97 @@ RSpec.describe Truemail::Validate::DomainListMatch do
     let(:domain) { email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1] }
     let(:result_instance) { Truemail::Validator::Result.new(email: email) }
 
-    context 'when email domain in white list' do
-      specify do
-        allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
-        allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
-        expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
+    before do
+      allow(Truemail)
+        .to receive_message_chain(:configuration, :whitelist_validation)
+        .and_return(whitelist_validation_condition)
+    end
+
+    context 'when whitelist validation not configured' do
+      let(:whitelist_validation_condition) { false }
+
+      context 'when email domain in white list' do
+        specify do
+          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
+          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+          expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
+        end
+      end
+
+      context 'when email domain in black list' do
+        specify do
+          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
+          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
+          expect { list_match_validator }
+            .to change(result_instance, :success).from(nil).to(false)
+            .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
+        end
+      end
+
+      context 'when email domain exists on both lists' do
+        specify do
+          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
+          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
+          expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
+        end
+      end
+
+      context 'when email domain exists not on both lists' do
+        specify do
+          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
+          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+          expect { list_match_validator }.not_to change(result_instance, :success)
+        end
       end
     end
 
-    context 'when email domain in black list' do
-      specify do
-        allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
-        allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
-        expect { list_match_validator }
-          .to change(result_instance, :success).from(nil).to(false)
-          .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
-      end
-    end
+    context 'when whitelist validation configured' do
+      let(:whitelist_validation_condition) { true }
 
-    context 'when email domain not on both lists' do
-      specify do
-        allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
-        allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
-        expect { list_match_validator }.not_to change(result_instance, :success)
+      context 'when email domain whitelisted in configuration' do
+        before do
+          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
+        end
+
+        context 'when email domain in white list' do
+          specify do
+            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+            expect { list_match_validator }.not_to change(result_instance, :success)
+          end
+        end
+
+        context 'when email domain exists on both lists' do
+          specify do
+            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
+            expect { list_match_validator }
+              .to change(result_instance, :success).from(nil).to(false)
+              .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
+          end
+        end
+      end
+
+      context 'when email domain not whitelisted in configuration' do
+        before do
+          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
+        end
+
+        context 'when email domain in black list' do
+          specify do
+            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+            expect { list_match_validator }
+              .to change(result_instance, :success).from(nil).to(false)
+              .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
+          end
+        end
+
+        context 'when email domain not exists on both lists' do
+          specify do
+            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+            expect { list_match_validator }
+              .to change(result_instance, :success).from(nil).to(false)
+              .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Implement configurable option: validation for whitelisted domains only.

When email domain in whitelist and ```whitelist_validation``` is sets equal to ```true``` validation type will be passed to other validators. Validation of email which not contains whitelisted domain always will return ```false```.

```ruby
Truemail.configure do |config|
  config.verifier_email = 'verifier@example.com'
  config.whitelisted_domains = ['white-domain.com']
  config.whitelist_validation = true
end
```

###### Email has whitelisted domain

```ruby
Truemail.validate('email@white-domain.com', with: :regex)

#<Truemail::Validator:0x000055b8429f3490
  @result=#<struct Truemail::Validator::Result
    success=true,
    email="email@white-domain.com",
    domain=nil,
    mail_servers=[],
    errors={},
    smtp_debug=nil>,
  @validation_type=:regex>
```

###### Email hasn't whitelisted domain

```ruby
Truemail.validate('email@domain.com', with: :regex)

#<Truemail::Validator:0x000055b8429f3490
  @result=#<struct Truemail::Validator::Result
    success=false,
    email="email@domain.com",
    domain=nil,
    mail_servers=[],
    errors={},
    smtp_debug=nil>,
  @validation_type=:blacklist>
```

- [x] Added validation for whitelisted domains configurable option
- [x] Updated tests
- [x] Updated documentation
- [x] Updated wiki
- [x] Updated gem version