### PR TITLE
Feature/Independent configuration instance

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -17,6 +17,7 @@ detectors:
   TooManyInstanceVariables:
     exclude:
      - Truemail::Configuration
+     - Truemail::Validate::Smtp::Request
 
   Attribute:
     exclude:
@@ -40,11 +41,13 @@ detectors:
       - Truemail::Worker#success
       - Truemail#raise_unless
       - Truemail::Configuration#raise_unless
+      - Truemail#determine_configuration
 
   FeatureEnvy:
     exclude:
       - Truemail::Validate::Smtp#not_includes_user_not_found_errors
       - Truemail::GenerateEmailHelper#prepare_user_name
+      - Truemail::ConfigurationHelper#create_configuration
 
   NilCheck:
     exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.2.1)
+    truemail (1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/657aa241399927dcd2e2/maintainability)](https://codeclimate.com/github/rubygarage/truemail/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/657aa241399927dcd2e2/test_coverage)](https://codeclimate.com/github/rubygarage/truemail/test_coverage) [![CircleCI](https://circleci.com/gh/rubygarage/truemail/tree/master.svg?style=svg)](https://circleci.com/gh/rubygarage/truemail/tree/master) [![Gem Version](https://badge.fury.io/rb/truemail.svg)](https://badge.fury.io/rb/truemail) [![Downloads](https://img.shields.io/gem/dt/truemail.svg?colorA=004d99&colorB=0073e6)](https://rubygems.org/gems/truemail) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
-The Truemail gem helps you validate emails by regex pattern, presence of domain mx-records, and real existence of email account on a current email server. Also Truemail gem allows performing an audit of the host in which runs.
+The Truemail gem helps you validate emails via regex pattern, presence of DNS records, and real existence of email account on a current email server. Also Truemail gem allows performing an audit of the host in which runs.
 
 ## Features
 
@@ -34,17 +34,19 @@ Email validation is a tricky thing. There are a number of different ways to vali
 
 **Syntax Checking**: Checks the email addresses via regex pattern.
 
-**Mail Server Existence Check**: Checks the availability of the email address domain using DNS MX records.
+**Mail Server Existence Check**: Checks the availability of the email address domain using DNS records.
 
 **Mail Existence Check**: Checks if the email address really exists and can receive email via SMTP connections and email-sending emulation techniques.
 
 ## Usage
 
-### Configuration features 
+### Configuration features
 
-#### Set configuration
+You can use global gem configuration or custom independent configuration.
 
-To have an access for ```Truemail.configuration``` and gem features, you must configure it first as in the example below:
+#### Setting global configuration
+
+To have an access for ```Truemail.configuration``` and gem configuration features, you must configure it first as in the example below:
 
 ```ruby
 require 'truemail'
@@ -110,7 +112,7 @@ Truemail.configure do |config|
 end
 ```
 
-#### Read configuration
+##### Read global configuration
 
 After successful configuration, you can read current Truemail configuration instance anywhere in your application.
 
@@ -132,7 +134,7 @@ Truemail.configuration
  @smtp_safe_check=true>
 ```
 
-#### Update configuration
+##### Update global configuration
 
 ```ruby
 Truemail.configuration.connection_timeout = 3
@@ -158,7 +160,7 @@ Truemail.configuration
  @smtp_safe_check=true>
 ```
 
-#### Reset configuration
+##### Reset global configuration
 
 Also you can reset Truemail configuration.
 
@@ -168,6 +170,23 @@ Truemail.reset_configuration!
 Truemail.configuration
 => nil
 ```
+
+#### Using custom independent configuration
+
+Allows to use independent configuration for each validation/audition instance. When using this feature you do not need to have Truemail global configuration.
+
+```ruby
+custom_configuration = Truemail::Configuration.new do |config|
+  config.verifier_email = 'verifier@example.com'
+end
+
+Truemail.validate('email@example.com', custom_configuration: custom_configuration)
+Truemail.valid?('email@example.com', custom_configuration: custom_configuration)
+Truemail.host_audit('email@example.com', custom_configuration: custom_configuration)
+```
+
+Please note, you should have global or custom configuration for use Truemail gem.
+
 
 ### Validation features
 
@@ -210,6 +229,20 @@ Truemail.validate('email@white-domain.com')
     mail_servers=[],
     errors={},
     smtp_debug=nil>,
+    configuration=#<Truemail::Configuration:0x00005629f801bd28
+     @blacklisted_domains=["black-domain.com", "somedomain.com"],
+     @connection_attempts=2,
+     @connection_timeout=2,
+     @default_validation_type=:smtp,
+     @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+     @response_timeout=2,
+     @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+     @smtp_safe_check=false,
+     @validation_type_by_domain={"somedomain.com"=>:mx},
+     @verifier_domain="example.com",
+     @verifier_email="verifier@example.com",
+     @whitelist_validation=false,
+     @whitelisted_domains=["white-domain.com", "somedomain.com"]>,
   @validation_type=:whitelist>
 ```
 
@@ -241,6 +274,21 @@ Truemail.validate('email@white-domain.com', with: :regex)
     mail_servers=[],
     errors={},
     smtp_debug=nil>,
+    configuration=
+    #<Truemail::Configuration:0x0000563f0d2605c8
+     @blacklisted_domains=[],
+     @connection_attempts=2,
+     @connection_timeout=2,
+     @default_validation_type=:smtp,
+     @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+     @response_timeout=2,
+     @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+     @smtp_safe_check=false,
+     @validation_type_by_domain={},
+     @verifier_domain="example.com",
+     @verifier_email="verifier@example.com",
+     @whitelist_validation=true,
+     @whitelisted_domains=["white-domain.com"]>,
   @validation_type=:regex>
 ```
 
@@ -257,6 +305,21 @@ Truemail.validate('email@domain.com', with: :regex)
     mail_servers=[],
     errors={},
     smtp_debug=nil>,
+    configuration=
+    #<Truemail::Configuration:0x0000563f0cd82ab0
+     @blacklisted_domains=[],
+     @connection_attempts=2,
+     @connection_timeout=2,
+     @default_validation_type=:smtp,
+     @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+     @response_timeout=2,
+     @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+     @smtp_safe_check=false,
+     @validation_type_by_domain={},
+     @verifier_domain="example.com",
+     @verifier_email="verifier@example.com",
+     @whitelist_validation=true,
+     @whitelisted_domains=["white-domain.com"]>,
   @validation_type=:blacklist>
 ```
 
@@ -275,6 +338,21 @@ Truemail.validate('email@black-domain.com')
     mail_servers=[],
     errors={},
     smtp_debug=nil>,
+    configuration=
+    #<Truemail::Configuration:0x0000563f0d36f4f0
+     @blacklisted_domains=[],
+     @connection_attempts=2,
+     @connection_timeout=2,
+     @default_validation_type=:smtp,
+     @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+     @response_timeout=2,
+     @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+     @smtp_safe_check=false,
+     @validation_type_by_domain={},
+     @verifier_domain="example.com",
+     @verifier_email="verifier@example.com",
+     @whitelist_validation=true,
+     @whitelisted_domains=["white-domain.com"]>,
   @validation_type=:blacklist>
 ```
 
@@ -293,6 +371,21 @@ Truemail.validate('email@somedomain.com')
     mail_servers=[],
     errors={},
     smtp_debug=nil>,
+    configuration=
+    #<Truemail::Configuration:0x0000563f0d3f8fc0
+     @blacklisted_domains=[],
+     @connection_attempts=2,
+     @connection_timeout=2,
+     @default_validation_type=:smtp,
+     @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+     @response_timeout=2,
+     @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+     @smtp_safe_check=false,
+     @validation_type_by_domain={},
+     @verifier_domain="example.com",
+     @verifier_email="verifier@example.com",
+     @whitelist_validation=true,
+     @whitelisted_domains=["white-domain.com"]>,
   @validation_type=:whitelist>
 ```
 
@@ -327,6 +420,21 @@ Truemail.validate('email@example.com', with: :regex)
       mail_servers=[],
       errors={},
       smtp_debug=nil>,
+      configuration=
+      #<Truemail::Configuration:0x000055aa56a54d48
+       @blacklisted_domains=[],
+       @connection_attempts=2,
+       @connection_timeout=2,
+       @default_validation_type=:smtp,
+       @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+       @response_timeout=2,
+       @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+       @smtp_safe_check=false,
+       @validation_type_by_domain={},
+       @verifier_domain="example.com",
+       @verifier_email="verifier@example.com",
+       @whitelist_validation=false,
+       @whitelisted_domains=[]>,
   @validation_type=:regex>
 ```
 
@@ -351,6 +459,21 @@ Truemail.validate('email@example.com', with: :regex)
       mail_servers=[],
       errors={},
       smtp_debug=nil>,
+      configuration=
+      #<Truemail::Configuration:0x0000560e58d80830
+       @blacklisted_domains=[],
+       @connection_attempts=2,
+       @connection_timeout=2,
+       @default_validation_type=:smtp,
+       @email_pattern=/regex_pattern/,
+       @response_timeout=2,
+       @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+       @smtp_safe_check=false,
+       @validation_type_by_domain={},
+       @verifier_domain="example.com",
+       @verifier_email="verifier@example.com",
+       @whitelist_validation=false,
+       @whitelisted_domains=[]>,
   @validation_type=:regex>
 ```
 
@@ -384,6 +507,21 @@ Truemail.validate('email@example.com', with: :mx)
       mail_servers=["127.0.1.1", "127.0.1.2"],
       errors={},
       smtp_debug=nil>,
+      configuration=
+      #<Truemail::Configuration:0x0000559b6e44af70
+       @blacklisted_domains=[],
+       @connection_attempts=2,
+       @connection_timeout=2,
+       @default_validation_type=:smtp,
+       @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+       @response_timeout=2,
+       @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+       @smtp_safe_check=false,
+       @validation_type_by_domain={},
+       @verifier_domain="example.com",
+       @verifier_email="verifier@example.com",
+       @whitelist_validation=false,
+       @whitelisted_domains=[]>,
   @validation_type=:mx>
 ```
 
@@ -420,6 +558,21 @@ Truemail.validate('email@example.com')
       mail_servers=["127.0.1.1", "127.0.1.2"],
       errors={},
       smtp_debug=nil>,
+      configuration=
+      #<Truemail::Configuration:0x00005615e87b9298
+       @blacklisted_domains=[],
+       @connection_attempts=2,
+       @connection_timeout=2,
+       @default_validation_type=:smtp,
+       @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+       @response_timeout=2,
+       @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+       @smtp_safe_check=false,
+       @validation_type_by_domain={},
+       @verifier_domain="example.com",
+       @verifier_email="verifier@example.com",
+       @whitelist_validation=false,
+       @whitelisted_domains=[]>,
   @validation_type=:smtp>
 
 # SMTP validation failed
@@ -434,17 +587,9 @@ Truemail.validate('email@example.com')
         smtp_debug=
           [#<Truemail::Validate::Smtp::Request:0x0000000002d49b10
             @configuration=
-              #<Truemail::Configuration:0x0000000002d49930
+              #<Truemail::Validate::Smtp::Request::Configuration:0x00005615e8d21848
               @connection_timeout=2,
-              @email_pattern=/regex_pattern/,
-              @smtp_error_body_pattern=/regex_pattern/,
               @response_timeout=2,
-              @connection_attempts=2,
-              @smtp_safe_check=false,
-              @validation_type_by_domain={},
-              @whitelisted_domains=[],
-              @whitelist_validation=false,
-              @blacklisted_domains=[],
               @verifier_domain="example.com",
               @verifier_email="verifier@example.com">,
             @email="email@example.com",
@@ -464,6 +609,21 @@ Truemail.validate('email@example.com')
                     @string="250 OK\n">,
                 rcptto=false,
                 errors={:rcptto=>"550 User not found\n"}>>]>,
+          configuration=
+            #<Truemail::Configuration:0x00005615e87b9298
+             @blacklisted_domains=[],
+             @connection_attempts=2,
+             @connection_timeout=2,
+             @default_validation_type=:smtp,
+             @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+             @response_timeout=2,
+             @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+             @smtp_safe_check=false,
+             @validation_type_by_domain={},
+             @verifier_domain="example.com",
+             @verifier_email="verifier@example.com",
+             @whitelist_validation=false,
+             @whitelisted_domains=[]>,
     @validation_type=:smtp>
 ```
 
@@ -491,33 +651,40 @@ Truemail.validate('email@example.com')
         smtp_debug=
           [#<Truemail::Validate::Smtp::Request:0x0000000002c95d40
             @configuration=
-              #<Truemail::Configuration:0x0000000002c95b38
-                @connection_timeout=2,
-                @email_pattern=/regex_pattern/,
-                @smtp_error_body_pattern=/regex_pattern/,
-                @response_timeout=2,
-                @connection_attempts=2,
-                @smtp_safe_check=true,
-                @validation_type_by_domain={},
-                @whitelisted_domains=[],
-                @whitelist_validation=false,
-                @blacklisted_domains=[],
-                @verifier_domain="example.com",
-                @verifier_email="verifier@example.com">,
-              @email="email@example.com",
-              @host="127.0.1.1",
-              @attempts=nil,
-              @response=
-                #<struct Truemail::Validate::Smtp::Response
-                  port_opened=true,
-                  connection=false,
-                  helo=
-                    #<Net::SMTP::Response:0x0000000002c934c8
-                    @status="250",
-                    @string="250 127.0.1.1\n">,
-                  mailfrom=false,
-                  rcptto=nil,
-                  errors={:mailfrom=>"554 5.7.1 Client host blocked\n", :connection=>"server dropped connection after response"}>>,]>,
+              #<Truemail::Validate::Smtp::Request::Configuration:0x00005615e8d21848
+              @connection_timeout=2,
+              @response_timeout=2,
+              @verifier_domain="example.com",
+              @verifier_email="verifier@example.com">,
+            @email="email@example.com",
+            @host="127.0.1.1",
+            @attempts=nil,
+            @response=
+              #<struct Truemail::Validate::Smtp::Response
+                port_opened=true,
+                connection=false,
+                helo=
+                  #<Net::SMTP::Response:0x0000000002c934c8
+                  @status="250",
+                  @string="250 127.0.1.1\n">,
+                mailfrom=false,
+                rcptto=nil,
+                errors={:mailfrom=>"554 5.7.1 Client host blocked\n", :connection=>"server dropped connection after response"}>>,]>,
+        configuration=
+            #<Truemail::Configuration:0x00005615e87b9298
+             @blacklisted_domains=[],
+             @connection_attempts=2,
+             @connection_timeout=2,
+             @default_validation_type=:smtp,
+             @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+             @response_timeout=2,
+             @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+             @smtp_safe_check=false,
+             @validation_type_by_domain={},
+             @verifier_domain="example.com",
+             @verifier_email="verifier@example.com",
+             @whitelist_validation=false,
+             @whitelisted_domains=[]>,
     @validation_type=:smtp>
 
 # SMTP validation failed
@@ -532,17 +699,9 @@ Truemail.validate('email@example.com')
       smtp_debug=
         [#<Truemail::Validate::Smtp::Request:0x0000000002d49b10
           @configuration=
-            #<Truemail::Configuration:0x0000000002d49930
+              #<Truemail::Validate::Smtp::Request::Configuration:0x00005615e8d21848
               @connection_timeout=2,
-              @email_pattern=/regex_pattern/,
-              @smtp_error_body_pattern=/regex_pattern/,
               @response_timeout=2,
-              @connection_attempts=2,
-              @smtp_safe_check=true,
-              @validation_type_by_domain={},
-              @whitelisted_domains=[],
-              @whitelist_validation=false,
-              @blacklisted_domains=[],
               @verifier_domain="example.com",
               @verifier_email="verifier@example.com">,
           @email="email@example.com",
@@ -559,6 +718,21 @@ Truemail.validate('email@example.com')
               mailfrom=#<Net::SMTP::Response:0x0000000002d5a618 @status="250", @string="250 OK\n">,
               rcptto=false,
               errors={:rcptto=>"550 User not found\n"}>>]>,
+      configuration=
+            #<Truemail::Configuration:0x00005615e87b9298
+             @blacklisted_domains=[],
+             @connection_attempts=2,
+             @connection_timeout=2,
+             @default_validation_type=:smtp,
+             @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+             @response_timeout=2,
+             @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+             @smtp_safe_check=false,
+             @validation_type_by_domain={},
+             @verifier_domain="example.com",
+             @verifier_email="verifier@example.com",
+             @whitelist_validation=false,
+             @whitelisted_domains=[]>,
     @validation_type=:smtp>
 ```
 
@@ -576,14 +750,44 @@ Truemail.host_audit
 => #<Truemail::Auditor:0x00005580df358828
    @result=
      #<struct Truemail::Auditor::Result
-       warnings={}>>
+       warnings={}>,
+       configuration=
+        #<Truemail::Configuration:0x00005615e86327a8
+         @blacklisted_domains=[],
+         @connection_attempts=2,
+         @connection_timeout=2,
+         @default_validation_type=:smtp,
+         @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+         @response_timeout=2,
+         @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+         @smtp_safe_check=false,
+         @validation_type_by_domain={},
+         @verifier_domain="example.com",
+         @verifier_email="verifier@example.com",
+         @whitelist_validation=false,
+         @whitelisted_domains=[]>
 
 # Has PTR warning
 => #<Truemail::Auditor:0x00005580df358828
    @result=
      #<struct Truemail::Auditor::Result
        warnings=
-         {:ptr=>"ptr record does not reference to current verifier domain"}>>
+         {:ptr=>"ptr record does not reference to current verifier domain"}>,
+       configuration=
+        #<Truemail::Configuration:0x00005615e86327a8
+         @blacklisted_domains=[],
+         @connection_attempts=2,
+         @connection_timeout=2,
+         @default_validation_type=:smtp,
+         @email_pattern=/(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@((?i-mx:[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}))\z)/,
+         @response_timeout=2,
+         @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+         @smtp_safe_check=false,
+         @validation_type_by_domain={},
+         @verifier_domain="example.com",
+         @verifier_email="verifier@example.com",
+         @whitelist_validation=false,
+         @whitelisted_domains=[]>
 ```
 
 ### Truemail helpers

--- a/lib/truemail.rb
+++ b/lib/truemail.rb
@@ -12,7 +12,7 @@ module Truemail
         return unless block_given?
         configuration = Truemail::Configuration.new
         yield(configuration)
-        raise_unless(configuration.complete?, INCOMPLETE_CONFIG)
+        raise_unless(configuration.complete?, Truemail::INCOMPLETE_CONFIG)
         configuration
       end
     end
@@ -26,7 +26,7 @@ module Truemail
     end
 
     def validate(email, **options)
-      raise_unless(configuration, NOT_CONFIGURED)
+      raise_unless(configuration, Truemail::NOT_CONFIGURED)
       Truemail::Validator.new(email, **options).run
     end
 

--- a/lib/truemail.rb
+++ b/lib/truemail.rb
@@ -4,7 +4,7 @@ require 'truemail/core'
 
 module Truemail
   INCOMPLETE_CONFIG = 'verifier_email is required parameter'
-  NOT_CONFIGURED = 'use Truemail.configure before'
+  NOT_CONFIGURED = 'use Truemail.configure before or pass custom configuration'
 
   class << self
     def configuration
@@ -25,24 +25,29 @@ module Truemail
       @configuration = nil
     end
 
-    def validate(email, **options)
-      raise_unless(configuration, Truemail::NOT_CONFIGURED)
-      Truemail::Validator.new(email, **options).run
+    def validate(email, custom_configuration: nil, **options)
+      Truemail::Validator.new(email, configuration: determine_configuration(custom_configuration), **options).run
     end
 
     def valid?(email, **options)
       validate(email, **options).result.valid?
     end
 
-    def host_audit
-      raise_unless(configuration, NOT_CONFIGURED)
-      Truemail::Auditor.run
+    def host_audit(custom_configuration: nil)
+      Truemail::Auditor.new(configuration: determine_configuration(custom_configuration)).run
     end
 
     private
 
     def raise_unless(condition, message)
-      raise ConfigurationError, message unless condition
+      raise Truemail::ConfigurationError, message unless condition
+    end
+
+    def determine_configuration(custom_configuration)
+      current_configuration = custom_configuration || configuration
+      raise_unless(current_configuration, Truemail::NOT_CONFIGURED)
+      raise_unless(current_configuration.complete?, Truemail::INCOMPLETE_CONFIG)
+      current_configuration.dup.freeze
     end
   end
 end

--- a/lib/truemail/audit/base.rb
+++ b/lib/truemail/audit/base.rb
@@ -9,8 +9,12 @@ module Truemail
         result.warnings[self.class.name.split('::').last.downcase.to_sym] = message
       end
 
+      def configuration
+        result.configuration
+      end
+
       def verifier_domain
-        Truemail.configuration.verifier_domain
+        configuration.verifier_domain
       end
     end
   end

--- a/lib/truemail/audit/ptr.rb
+++ b/lib/truemail/audit/ptr.rb
@@ -27,7 +27,9 @@ module Truemail
       end
 
       def current_host_address
-        @current_host_address ||= Truemail::Wrapper.call { IPAddr.new(detect_ip_via_ipify) }
+        @current_host_address ||= Truemail::Wrapper.call(configuration: configuration) do
+          IPAddr.new(detect_ip_via_ipify)
+        end
       end
 
       def current_host_reverse_lookup
@@ -35,7 +37,7 @@ module Truemail
       end
 
       def ptr_records
-        @ptr_records ||= Truemail::Wrapper.call do
+        @ptr_records ||= Truemail::Wrapper.call(configuration: configuration) do
           Resolv::DNS.new.getresources(
             current_host_reverse_lookup, Resolv::DNS::Resource::IN::PTR
           ).map { |ptr_record| ptr_record.name.to_s }
@@ -47,11 +49,13 @@ module Truemail
       end
 
       def a_record
-        Truemail::Wrapper.call { Resolv::DNS.new.getaddress(verifier_domain).to_s }
+        Truemail::Wrapper.call(configuration: configuration) do
+          Resolv::DNS.new.getaddress(verifier_domain).to_s
+        end
       end
 
       def verifier_domain_refer_to_current_host_address?
-        a_record == current_host_address.to_s
+        a_record.eql?(current_host_address.to_s)
       end
     end
   end

--- a/lib/truemail/auditor.rb
+++ b/lib/truemail/auditor.rb
@@ -2,18 +2,16 @@
 
 module Truemail
   class Auditor
-    Result = Struct.new(:warnings, keyword_init: true) do
+    Result = Struct.new(:warnings, :configuration, keyword_init: true) do
       def initialize(warnings: {}, **args)
         super
       end
     end
 
-    def self.run
-      new.run
-    end
+    attr_reader :result
 
-    def result
-      @result ||= Truemail::Auditor::Result.new
+    def initialize(configuration:)
+      @result = Truemail::Auditor::Result.new(configuration: configuration)
     end
 
     def run

--- a/lib/truemail/configuration.rb
+++ b/lib/truemail/configuration.rb
@@ -17,7 +17,8 @@ module Truemail
                 :default_validation_type,
                 :validation_type_by_domain,
                 :whitelisted_domains,
-                :blacklisted_domains
+                :blacklisted_domains,
+                :error_log
 
     attr_accessor :whitelist_validation, :smtp_safe_check
 
@@ -69,6 +70,10 @@ module Truemail
         raise_unless(argument, __method__, argument.is_a?(Array) && check_domain_list(argument))
         instance_variable_set(:"@#{method}", argument)
       end
+    end
+
+    def error_log=(absolute_file_path)
+      @error_log = Truemail::Logger.new(absolute_file_path)
     end
 
     def complete?

--- a/lib/truemail/configuration.rb
+++ b/lib/truemail/configuration.rb
@@ -17,17 +17,17 @@ module Truemail
                 :default_validation_type,
                 :validation_type_by_domain,
                 :whitelisted_domains,
-                :blacklisted_domains,
-                :error_log
+                :blacklisted_domains
 
     attr_accessor :whitelist_validation, :smtp_safe_check
 
     alias retry_count connection_attempts
 
-    def initialize
+    def initialize(&block)
       instance_initializer.each do |instace_variable, value|
         instance_variable_set(:"@#{instace_variable}", value)
       end
+      tap(&block) if block_given?
     end
 
     %i[email_pattern smtp_error_body_pattern].each do |method|
@@ -70,10 +70,6 @@ module Truemail
         raise_unless(argument, __method__, argument.is_a?(Array) && check_domain_list(argument))
         instance_variable_set(:"@#{method}", argument)
       end
-    end
-
-    def error_log=(absolute_file_path)
-      @error_log = Truemail::Logger.new(absolute_file_path)
     end
 
     def complete?

--- a/lib/truemail/logger.rb
+++ b/lib/truemail/logger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.3.0'
+  class Logger
+  end
 end

--- a/lib/truemail/logger.rb
+++ b/lib/truemail/logger.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Truemail
-  class Logger
-  end
-end

--- a/lib/truemail/validate/base.rb
+++ b/lib/truemail/validate/base.rb
@@ -14,7 +14,7 @@ module Truemail
       end
 
       def configuration
-        Truemail.configuration
+        result.configuration
       end
     end
   end

--- a/lib/truemail/validate/mx.rb
+++ b/lib/truemail/validate/mx.rb
@@ -24,7 +24,7 @@ module Truemail
 
       def mx_lookup
         host_extractor_methods.any? do |method|
-          Truemail::Wrapper.call { send(method) }
+          Truemail::Wrapper.call(configuration: configuration) { send(method) }
         end
       end
 

--- a/lib/truemail/validate/smtp.rb
+++ b/lib/truemail/validate/smtp.rb
@@ -40,7 +40,7 @@ module Truemail
       def establish_smtp_connection
         mail_servers.each do |mail_server|
           smtp_results << Truemail::Validate::Smtp::Request.new(
-            host: mail_server, email: result.email, **attempts
+            configuration: configuration, host: mail_server, email: result.email, **attempts
           )
           next unless request.check_port
           request.run || rcptto_error ? break : next

--- a/lib/truemail/validator.rb
+++ b/lib/truemail/validator.rb
@@ -2,7 +2,7 @@
 
 module Truemail
   class Validator
-    RESULT_ATTRS = %i[success email domain mail_servers errors smtp_debug].freeze
+    RESULT_ATTRS = %i[success email domain mail_servers errors smtp_debug configuration].freeze
     VALIDATION_TYPES = %i[regex mx smtp].freeze
 
     Result = Struct.new(*RESULT_ATTRS, keyword_init: true) do
@@ -14,10 +14,11 @@ module Truemail
 
     attr_reader :validation_type, :result
 
-    def initialize(email, with: Truemail.configuration.default_validation_type)
+    def initialize(email, with: nil, configuration:)
+      with ||= configuration.default_validation_type
       raise Truemail::ArgumentError.new(with, :argument) unless Truemail::Validator::VALIDATION_TYPES.include?(with)
+      @result = Truemail::Validator::Result.new(email: email, configuration: configuration)
       @validation_type = select_validation_type(email, with)
-      @result = Truemail::Validator::Result.new(email: email)
     end
 
     def run
@@ -38,7 +39,7 @@ module Truemail
 
     def select_validation_type(email, current_validation_type)
       domain = email[Truemail::RegexConstant::REGEX_EMAIL_PATTERN, 3]
-      Truemail.configuration.validation_type_by_domain[domain] || current_validation_type
+      result.configuration.validation_type_by_domain[domain] || current_validation_type
     end
   end
 end

--- a/lib/truemail/wrapper.rb
+++ b/lib/truemail/wrapper.rb
@@ -2,18 +2,20 @@
 
 module Truemail
   class Wrapper
+    attr_reader :timeout
     attr_accessor :attempts
 
-    def self.call(&block)
-      new.call(&block)
+    def self.call(configuration:, &block)
+      new(configuration).call(&block)
     end
 
-    def initialize
-      @attempts = Truemail.configuration.connection_attempts
+    def initialize(configuration)
+      @attempts = configuration.connection_attempts
+      @timeout = configuration.connection_timeout
     end
 
     def call(&block)
-      Timeout.timeout(Truemail.configuration.connection_timeout, &block)
+      Timeout.timeout(timeout, &block)
     rescue Resolv::ResolvError, IPAddr::InvalidAddressError
       false
     rescue Timeout::Error

--- a/spec/support/helpers/configuration_helper.rb
+++ b/spec/support/helpers/configuration_helper.rb
@@ -9,5 +9,10 @@ module Truemail
         end
       end
     end
+
+    def create_configuration(**configuration_settings)
+      configuration_settings[:verifier_email] = FFaker::Internet.email unless configuration_settings[:verifier_email]
+      Truemail::Configuration.new(&configuration_block(configuration_settings))
+    end
   end
 end

--- a/spec/support/helpers/configuration_helper_spec.rb
+++ b/spec/support/helpers/configuration_helper_spec.rb
@@ -2,7 +2,7 @@
 
 module Truemail
   RSpec.describe ConfigurationHelper, type: :helper do
-    describe '.configuration_block' do
+    describe '#configuration_block' do
       let(:configuration_params) { { param_1: 1, param_2: 2 } }
       let(:configuration_instance) { Struct.new(*configuration_params.keys).new }
 
@@ -13,6 +13,29 @@ module Truemail
       it 'sets configuration instance attributes' do
         configuration_params.each do |attribute, value|
           expect(configuration_instance.public_send(attribute)).to eq(value)
+        end
+      end
+    end
+
+    describe '#create_configuration' do
+      subject(:configuration_builder) { create_configuration(params) }
+
+      let(:params) { {} }
+
+      context 'with default params' do
+        it 'returns configuration instance with random verifier email' do
+          expect(configuration_builder).to be_an_instance_of(Truemail::Configuration)
+          expect(configuration_builder.verifier_email).not_to be_nil
+        end
+      end
+
+      context 'with custom params' do
+        let(:verifier_email) { FFaker::Internet.email }
+        let(:params) { { verifier_email: verifier_email } }
+
+        it 'returns configuration instance with custom verifier email' do
+          expect(configuration_builder).to be_an_instance_of(Truemail::Configuration)
+          expect(configuration_builder.verifier_email).to eq(verifier_email)
         end
       end
     end

--- a/spec/truemail/audit/ptr_spec.rb
+++ b/spec/truemail/audit/ptr_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Truemail::Audit::Ptr do
-  let(:email) { FFaker::Internet.email }
-  let(:result_instance) { Truemail::Auditor::Result.new }
-
-  before { Truemail.configure { |config| config.verifier_email = email } }
+  let(:configuration_instance) { create_configuration }
+  let(:result_instance) { Truemail::Auditor::Result.new(configuration: configuration_instance) }
 
   describe 'defined constants' do
     specify { expect(described_class).to be_const_defined(:GET_MY_IP_URL) }
@@ -30,7 +28,7 @@ RSpec.describe Truemail::Audit::Ptr do
     subject(:ptr_auditor) { ptr_auditor_instance.run }
 
     let(:ptr_auditor_instance) { described_class.new(result_instance) }
-    let(:host_name) { Truemail.configuration.verifier_domain }
+    let(:host_name) { configuration_instance.verifier_domain }
     let(:host_address) { FFaker::Internet.ip_v4_address }
     let(:other_host_address) { '127.0.0.1' }
 

--- a/spec/truemail/auditor_spec.rb
+++ b/spec/truemail/auditor_spec.rb
@@ -2,23 +2,24 @@
 
 module Truemail
   RSpec.describe Truemail::Auditor do
-    subject(:auditor_instance) { described_class.run }
+    subject(:auditor_instance) { described_class.new(configuration: configuration_instance) }
 
-    let(:email) { FFaker::Internet.email }
-    let(:auditor_instance_result) { auditor_instance.result }
-
-    before { Truemail.configure { |config| config.verifier_email = email } }
+    let(:configuration_instance) { create_configuration }
 
     describe 'defined constants' do
       specify { expect(described_class).to be_const_defined(:Result) }
     end
 
-    describe '.run' do
-      it 'creates and updates default auditor result' do
-        allow(Truemail::Audit::Ptr).to receive(:check)
-        expect(auditor_instance).to be_an_instance_of(Truemail::Auditor)
-        expect(auditor_instance_result).to be_an_instance_of(Truemail::Auditor::Result)
-        expect(auditor_instance_result.warnings).to eq({})
+    describe '.new' do
+      it 'creates auditor with result getter' do
+        expect(auditor_instance.result).to be_an_instance_of(Truemail::Auditor::Result)
+      end
+    end
+
+    describe '#run' do
+      it 'runs audition methods' do
+        expect(Truemail::Audit::Ptr).to receive(:check)
+        expect(auditor_instance.run).to be_an_instance_of(described_class)
       end
     end
   end
@@ -26,18 +27,16 @@ module Truemail
   RSpec.describe Truemail::Auditor::Result do
     subject(:result_instance) { described_class.new }
 
-    let(:hash_object) { {} }
-
-    specify do
-      expect(result_instance.members).to include(:warnings)
+    it 'has attribute accessors warnings, configuration' do
+      expect(result_instance.members).to include(:warnings, :configuration)
     end
 
     it 'has default values for attributes' do
-      expect(result_instance.warnings).to eq(hash_object)
+      expect(result_instance.warnings).to eq({})
     end
 
     it 'accepts parametrized arguments' do
-      expect(described_class.new(warnings: hash_object).warnings).to eq(hash_object)
+      expect(described_class.new(warnings: :data).warnings).to eq(:data)
     end
   end
 end

--- a/spec/truemail/configuration_spec.rb
+++ b/spec/truemail/configuration_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe Truemail::Configuration do
   subject(:configuration_instance) { described_class.new }
 
+  let(:valid_email) { FFaker::Internet.email }
+
   describe 'defined constants' do
     specify { expect(described_class).to be_const_defined(:DEFAULT_CONNECTION_TIMEOUT) }
     specify { expect(described_class).to be_const_defined(:DEFAULT_RESPONSE_TIMEOUT) }
@@ -21,11 +23,16 @@ RSpec.describe Truemail::Configuration do
       expect(configuration_instance.respond_to?(:validation_type_for=)).to be(true)
     end
 
+    it 'accepts block' do
+      expect(
+        described_class.new(&configuration_block(verifier_email: valid_email)
+      ).verifier_email).to eq(valid_email)
+    end
+
     include_examples 'sets default configuration'
   end
 
   describe 'configuration cases' do
-    let(:valid_email) { FFaker::Internet.email }
     let(:default_verifier_domain) { valid_email[/\A(.+)@(.+)\z/, 2] }
 
     context 'when auto configuration' do

--- a/spec/truemail/validate/domain_list_match_spec.rb
+++ b/spec/truemail/validate/domain_list_match_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe Truemail::Validate::DomainListMatch do
 
     let(:email) { FFaker::Internet.email }
     let(:domain) { email[Truemail::RegexConstant::REGEX_DOMAIN_FROM_EMAIL, 1] }
-    let(:result_instance) { Truemail::Validator::Result.new(email: email) }
+    let(:configuration_instance) { create_configuration }
+    let(:result_instance) { Truemail::Validator::Result.new(email: email, configuration: configuration_instance) }
 
     before do
-      allow(Truemail)
-        .to receive_message_chain(:configuration, :whitelist_validation)
-        .and_return(whitelist_validation_condition)
+      allow(configuration_instance).to receive(:whitelist_validation).and_return(whitelist_validation_condition)
     end
 
     context 'when whitelist validation not configured' do
@@ -19,16 +18,16 @@ RSpec.describe Truemail::Validate::DomainListMatch do
 
       context 'when email domain in white list' do
         specify do
-          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
-          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+          allow(configuration_instance).to receive(:whitelisted_domains).and_return([domain])
+          allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
           expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
         end
       end
 
       context 'when email domain in black list' do
         specify do
-          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
-          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
+          allow(configuration_instance).to receive(:whitelisted_domains).and_return([])
+          allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
           expect { list_match_validator }
             .to change(result_instance, :success).from(nil).to(false)
             .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
@@ -37,16 +36,16 @@ RSpec.describe Truemail::Validate::DomainListMatch do
 
       context 'when email domain exists on both lists' do
         specify do
-          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
-          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
+          allow(configuration_instance).to receive(:whitelisted_domains).and_return([domain])
+          allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
           expect { list_match_validator }.to change(result_instance, :success).from(nil).to(true)
         end
       end
 
       context 'when email domain exists not on both lists' do
         specify do
-          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
-          allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+          allow(configuration_instance).to receive(:whitelisted_domains).and_return([])
+          allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
           expect { list_match_validator }.not_to change(result_instance, :success)
         end
       end
@@ -56,20 +55,18 @@ RSpec.describe Truemail::Validate::DomainListMatch do
       let(:whitelist_validation_condition) { true }
 
       context 'when email domain whitelisted in configuration' do
-        before do
-          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([domain])
-        end
+        before { allow(configuration_instance).to receive(:whitelisted_domains).and_return([domain]) }
 
         context 'when email domain in white list' do
           specify do
-            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+            allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
             expect { list_match_validator }.not_to change(result_instance, :success)
           end
         end
 
         context 'when email domain exists on both lists' do
           specify do
-            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([domain])
+            allow(configuration_instance).to receive(:blacklisted_domains).and_return([domain])
             expect { list_match_validator }
               .to change(result_instance, :success).from(nil).to(false)
               .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
@@ -79,12 +76,12 @@ RSpec.describe Truemail::Validate::DomainListMatch do
 
       context 'when email domain not whitelisted in configuration' do
         before do
-          allow(Truemail).to receive_message_chain(:configuration, :whitelisted_domains).and_return([])
+          allow(configuration_instance).to receive(:whitelisted_domains).and_return([])
         end
 
         context 'when email domain in black list' do
           specify do
-            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+            allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
             expect { list_match_validator }
               .to change(result_instance, :success).from(nil).to(false)
               .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })
@@ -93,7 +90,7 @@ RSpec.describe Truemail::Validate::DomainListMatch do
 
         context 'when email domain not exists on both lists' do
           specify do
-            allow(Truemail).to receive_message_chain(:configuration, :blacklisted_domains).and_return([])
+            allow(configuration_instance).to receive(:blacklisted_domains).and_return([])
             expect { list_match_validator }
               .to change(result_instance, :success).from(nil).to(false)
               .and change(result_instance, :errors).from({}).to({ domain_list_match: Truemail::Validate::DomainListMatch::ERROR })

--- a/spec/truemail/validate/mx_spec.rb
+++ b/spec/truemail/validate/mx_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe Truemail::Validate::Mx do
   let(:email) { FFaker::Internet.email }
-  let(:result_instance) { Truemail::Validator::Result.new(email: email) }
-
-  before { Truemail.configure { |config| config.verifier_email = email } }
+  let(:result_instance) { Truemail::Validator::Result.new(email: email, configuration: create_configuration) }
 
   describe 'defined constants' do
     specify { expect(described_class).to be_const_defined(:ERROR) }

--- a/spec/truemail/validate/regex_spec.rb
+++ b/spec/truemail/validate/regex_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe Truemail::Validate::Regex do
   describe '.check' do
     subject(:regex_validator) { described_class.check(result_instance) }
 
-    let(:result_instance) { Truemail::Validator::Result.new(email: FFaker::Internet.email) }
+    let(:configuration_instance) { create_configuration }
+    let(:result_instance) do
+      Truemail::Validator::Result.new(email: FFaker::Internet.email, configuration: configuration_instance)
+    end
 
     context 'when validation pass' do
       before do
-        allow(Truemail).to receive_message_chain(:configuration, :email_pattern, :match?).and_return(true)
+        allow(configuration_instance).to receive_message_chain(:email_pattern, :match?).and_return(true)
       end
 
       specify do
@@ -26,7 +29,7 @@ RSpec.describe Truemail::Validate::Regex do
 
     context 'when validation fails' do
       before do
-        allow(Truemail).to receive_message_chain(:configuration, :email_pattern, :match?).and_return(false)
+        allow(configuration_instance).to receive_message_chain(:email_pattern, :match?).and_return(false)
       end
 
       specify do

--- a/spec/truemail/validate/smtp/request_spec.rb
+++ b/spec/truemail/validate/smtp/request_spec.rb
@@ -1,259 +1,288 @@
 # frozen_string_literal: true
 
-RSpec.describe Truemail::Validate::Smtp::Request do
-  subject(:request_instance) do
-    described_class.new(host: mail_server, email: target_email, **attempts)
-  end
+module Truemail
+  RSpec.describe Truemail::Validate::Smtp::Request do
+    subject(:request_instance) do
+      described_class.new(
+        configuration: configuration_instance,
+        host: mail_server,
+        email: target_email,
+        **attempts
+      )
+    end
 
-  let(:mail_server)           { FFaker::Internet.domain_name }
-  let(:target_email)          { FFaker::Internet.email }
-  let(:response_instance)     { request_instance.response  }
-  let(:request_instance_host) { request_instance.host }
-  let(:configuration)         { request_instance.send(:configuration) }
-  let(:connection_timout)     { configuration.connection_timeout }
-  let(:response_timeout)      { configuration.response_timeout }
-  let(:attempts)              { {} }
+    let(:mail_server)            { FFaker::Internet.domain_name }
+    let(:target_email)           { FFaker::Internet.email }
+    let(:response_instance)      { request_instance.response }
+    let(:request_instance_host)  { request_instance.host }
+    let(:configuration_instance) { create_configuration }
+    let(:connection_timeout)     { configuration_instance.connection_timeout }
+    let(:response_timeout)       { configuration_instance.response_timeout }
+    let(:attempts)               { {} }
 
-  before { Truemail.configure { |config| config.verifier_email = FFaker::Internet.email } }
+    describe 'defined constants' do
+      specify { expect(described_class).to be_const_defined(:SMTP_PORT) }
+      specify { expect(described_class).to be_const_defined(:CONNECTION_TIMEOUT_ERROR) }
+      specify { expect(described_class).to be_const_defined(:RESPONSE_TIMEOUT_ERROR) }
+      specify { expect(described_class).to be_const_defined(:CONNECTION_DROPPED) }
+    end
 
-  describe 'defined constants' do
-    specify { expect(described_class).to be_const_defined(:SMTP_PORT) }
-    specify { expect(described_class).to be_const_defined(:CONNECTION_TIMEOUT_ERROR) }
-    specify { expect(described_class).to be_const_defined(:RESPONSE_TIMEOUT_ERROR) }
-    specify { expect(described_class).to be_const_defined(:CONNECTION_DROPPED) }
-  end
+    describe 'attribute readers' do
+      specify { expect(request_instance.public_methods).to include(:configuration, :host, :email, :response) }
+    end
 
-  describe 'attribute readers' do
-    specify { expect(request_instance.public_methods).to include(:host, :email, :response) }
-  end
+    describe '.new' do
+      specify { expect(request_instance.configuration).to be_an_instance_of(Truemail::Validate::Smtp::Request::Configuration) }
+      specify { expect(request_instance.host).to eq(mail_server) }
+      specify { expect(request_instance.email).to eq(target_email) }
+      specify { expect(request_instance.response).to be_an_instance_of(Truemail::Validate::Smtp::Response) }
+    end
 
-  describe '.new' do
-    specify { expect(request_instance.host).to eq(mail_server) }
-    specify { expect(request_instance.email).to eq(target_email) }
-    specify { expect(response_instance).to be_an_instance_of(Truemail::Validate::Smtp::Response) }
-  end
+    describe '#check_port' do
+      let(:response_instance_target_method) { request_instance.check_port }
 
-  describe '#check_port' do
-    let(:connection_timeout) { configuration.connection_timeout }
-    let(:response_instance_target_method) { request_instance.check_port }
+      context 'when port opened' do
+        specify do
+          allow(Timeout).to receive(:timeout).with(connection_timeout).and_call_original
+          allow(TCPSocket).to receive_message_chain(:new, :close)
+          expect { request_instance.check_port }
+            .to change(response_instance, :port_opened).from(nil).to(true)
+        end
+      end
 
-    context 'when port opened' do
-      specify do
-        allow(Timeout).to receive(:timeout).with(connection_timeout).and_call_original
-        allow(TCPSocket).to receive_message_chain(:new, :close)
-        expect { request_instance.check_port }
-          .to change(response_instance, :port_opened).from(nil).to(true)
+      context 'when port closed' do
+        let(:error_stubs) do
+          allow(Timeout).to receive(:timeout).with(connection_timeout).and_raise(Timeout::Error)
+        end
+
+        specify do
+          error_stubs
+          expect { response_instance_target_method }.to change(response_instance, :port_opened).from(nil).to(false)
+        end
+
+        specify do
+          allow(TCPSocket).to receive(:new).and_raise(SocketError)
+          expect { response_instance_target_method }.to change(response_instance, :port_opened).from(nil).to(false)
+        end
+
+        include_examples 'request retry behavior'
       end
     end
 
-    context 'when port closed' do
-      let(:error_stubs) do
-        allow(Timeout).to receive(:timeout).with(connection_timeout).and_raise(Timeout::Error)
-      end
+    describe '#session' do
+      context 'when session creates' do
+        let(:session) { request_instance.send(:session) }
 
-      specify do
-        error_stubs
-        expect { response_instance_target_method }.to change(response_instance, :port_opened).from(nil).to(false)
-      end
+        before do
+          allow(Net::SMTP)
+            .to receive(:new)
+            .with(request_instance_host, Truemail::Validate::Smtp::Request::SMTP_PORT)
+            .and_call_original
+        end
 
-      specify do
-        allow(TCPSocket).to receive(:new).and_raise(SocketError)
-        expect { response_instance_target_method }.to change(response_instance, :port_opened).from(nil).to(false)
-      end
+        it 'sets connection timeout with value from global configuration' do
+          expect(session.open_timeout).to eq(connection_timeout)
+        end
 
-      include_examples 'request retry behavior'
+        it 'sets response timeout with value from global configuration' do
+          expect(session.read_timeout).to eq(response_timeout)
+        end
+      end
     end
-  end
 
-  describe '#session' do
-    context 'when session creates' do
-      let(:session) { request_instance.send(:session) }
+    describe '#run' do
+      let(:response_instance_target_method) { request_instance.run }
 
       before do
+        allow(session).to receive(:open_timeout=).with(connection_timeout)
+        allow(session).to receive(:read_timeout=).with(response_timeout)
         allow(Net::SMTP)
-          .to receive(:new)
-          .with(request_instance_host, Truemail::Validate::Smtp::Request::SMTP_PORT)
-          .and_call_original
+            .to receive(:new)
+            .with(request_instance_host, Truemail::Validate::Smtp::Request::SMTP_PORT)
+            .and_return(session)
       end
 
-      it 'sets connection timeout with value from global configuration' do
-        expect(session.open_timeout).to eq(connection_timout)
-      end
-
-      it 'sets response timeout with value from global configuration' do
-        expect(session.read_timeout).to eq(response_timeout)
-      end
-    end
-  end
-
-  describe '#run' do
-    let(:response_instance_target_method) { request_instance.run }
-
-    before do
-      allow(session).to receive(:open_timeout=).with(connection_timout)
-      allow(session).to receive(:read_timeout=).with(response_timeout)
-      allow(Net::SMTP)
-          .to receive(:new)
-          .with(request_instance_host, Truemail::Validate::Smtp::Request::SMTP_PORT)
-          .and_return(session)
-    end
-
-    context 'when smtp communication complete successfully' do
-      let(:session) do
-        instance_double(
-          'Net::SMTP',
-          open_timeout: connection_timout,
-          read_timeout: response_timeout,
-          helo: true,
-          mailfrom: true,
-          rcptto: true
-        )
-      end
-
-      specify do
-        allow(session).to receive(:start).and_yield(session)
-
-        expect { response_instance_target_method }
-          .to change(response_instance, :connection).from(nil).to(true)
-          .and change(response_instance, :helo).from(nil).to(true)
-          .and change(response_instance, :mailfrom).from(nil).to(true)
-          .and change(response_instance, :rcptto).from(nil).to(true)
-          .and not_change(response_instance, :errors)
-
-        expect(response_instance_target_method).to be(true)
-      end
-    end
-
-    context 'when smtp communication fails' do
-      let(:error_message) { 'error message' }
-      let(:session) do
-        instance_double(
-          'Net::SMTP',
-          open_timeout: connection_timout,
-          read_timeout: response_timeout
-        )
-      end
-
-      context 'when connection timeout error' do
-        let(:error_stubs) do
-          allow(session).to receive(:start).and_raise(Net::OpenTimeout)
+      context 'when smtp communication complete successfully' do
+        let(:session) do
+          instance_double(
+            'Net::SMTP',
+            open_timeout: connection_timeout,
+            read_timeout: response_timeout,
+            helo: true,
+            mailfrom: true,
+            rcptto: true
+          )
         end
 
         specify do
-          error_stubs
-
-          expect { response_instance_target_method }
-            .to change(response_instance, :connection).from(nil).to(false)
-            .and change(response_instance, :errors)
-            .from({}).to({ connection: Truemail::Validate::Smtp::Request::CONNECTION_TIMEOUT_ERROR })
-            .and not_change(response_instance, :helo)
-            .and not_change(response_instance, :mailfrom)
-            .and not_change(response_instance, :rcptto)
-
-          expect(response_instance_target_method).to be(false)
-        end
-
-        include_examples 'request retry behavior'
-      end
-
-      context 'when remote server has dropped connection during session' do
-        let(:error_stubs) do
-          allow(session).to receive(:start).and_yield(session).and_raise(EOFError)
-          allow(session).to receive(:helo).and_raise(StandardError)
-        end
-
-        specify do
-          error_stubs
-
-          expect { response_instance_target_method }
-            .to change(response_instance, :connection).from(nil).to(false)
-            .and change(response_instance, :errors)
-            .from({}).to({ connection: Truemail::Validate::Smtp::Request::CONNECTION_DROPPED, helo: 'StandardError' })
-            .and change(response_instance, :helo).from(nil).to(false)
-            .and not_change(response_instance, :mailfrom)
-            .and not_change(response_instance, :rcptto)
-
-          expect(response_instance_target_method).to be(false)
-        end
-
-        include_examples 'request retry behavior'
-      end
-
-      context 'when connection other errors' do
-        let(:error_stubs) do
-          allow(session).to receive(:start).and_raise(StandardError, error_message)
-        end
-
-        specify do
-          error_stubs
-
-          expect { response_instance_target_method }
-            .to change(response_instance, :connection).from(nil).to(false)
-            .and change(response_instance, :errors)
-            .from({}).to({ connection: 'error message' })
-            .and not_change(response_instance, :helo)
-            .and not_change(response_instance, :mailfrom)
-            .and not_change(response_instance, :rcptto)
-
-          expect(response_instance_target_method).to be(false)
-        end
-
-        include_examples 'request retry behavior'
-      end
-
-      context 'when smtp response errors' do
-        it 'helo smtp server response timeout' do
           allow(session).to receive(:start).and_yield(session)
-          allow(session).to receive(:helo).and_raise(Net::ReadTimeout)
-          allow(session).to receive(:mailfrom)
-          allow(session).to receive(:rcptto)
-
-          expect { response_instance_target_method }
-            .to change(response_instance, :connection).from(nil).to(true)
-            .and change(response_instance, :helo).from(nil).to(false)
-            .and change(response_instance, :errors)
-            .from({}).to({ helo: Truemail::Validate::Smtp::Request::RESPONSE_TIMEOUT_ERROR })
-            .and not_change(response_instance, :mailfrom)
-            .and not_change(response_instance, :rcptto)
-
-          expect(session).not_to have_received(:mailfrom)
-          expect(session).not_to have_received(:rcptto)
-
-          expect(response_instance_target_method).to be(false)
-        end
-
-        it 'mailfrom smtp server error' do
-          allow(session).to receive(:start).and_yield(session)
-          allow(session).to receive(:helo).and_return(true)
-          allow(session).to receive(:mailfrom).and_raise(StandardError, error_message)
-          allow(session).to receive(:rcptto)
-
-          expect { response_instance_target_method }
-            .to change(response_instance, :connection).from(nil).to(true)
-            .and change(response_instance, :helo).from(nil).to(true)
-            .and change(response_instance, :mailfrom).from(nil).to(false)
-            .and change(response_instance, :errors).from({}).to({ mailfrom: error_message })
-            .and not_change(response_instance, :rcptto)
-
-          expect(session).not_to have_received(:rcptto)
-
-          expect(response_instance_target_method).to be(false)
-        end
-
-        it 'rcptto smtp server error' do
-          allow(session).to receive(:start).and_yield(session)
-          allow(session).to receive(:helo).and_return(true)
-          allow(session).to receive(:mailfrom).and_return(true)
-          allow(session).to receive(:rcptto).and_raise(StandardError, error_message)
 
           expect { response_instance_target_method }
             .to change(response_instance, :connection).from(nil).to(true)
             .and change(response_instance, :helo).from(nil).to(true)
             .and change(response_instance, :mailfrom).from(nil).to(true)
-            .and change(response_instance, :rcptto).from(nil).to(false)
-            .and change(response_instance, :errors).from({}).to({ rcptto: error_message })
+            .and change(response_instance, :rcptto).from(nil).to(true)
+            .and not_change(response_instance, :errors)
 
-          expect(response_instance_target_method).to be(false)
+          expect(response_instance_target_method).to be(true)
+        end
+      end
+
+      context 'when smtp communication fails' do
+        let(:error_message) { 'error message' }
+        let(:session) do
+          instance_double(
+            'Net::SMTP',
+            open_timeout: connection_timeout,
+            read_timeout: response_timeout
+          )
+        end
+
+        context 'when connection timeout error' do
+          let(:error_stubs) do
+            allow(session).to receive(:start).and_raise(Net::OpenTimeout)
+          end
+
+          specify do
+            error_stubs
+
+            expect { response_instance_target_method }
+              .to change(response_instance, :connection).from(nil).to(false)
+              .and change(response_instance, :errors)
+              .from({}).to({ connection: Truemail::Validate::Smtp::Request::CONNECTION_TIMEOUT_ERROR })
+              .and not_change(response_instance, :helo)
+              .and not_change(response_instance, :mailfrom)
+              .and not_change(response_instance, :rcptto)
+
+            expect(response_instance_target_method).to be(false)
+          end
+
+          include_examples 'request retry behavior'
+        end
+
+        context 'when remote server has dropped connection during session' do
+          let(:error_stubs) do
+            allow(session).to receive(:start).and_yield(session).and_raise(EOFError)
+            allow(session).to receive(:helo).and_raise(StandardError)
+          end
+
+          specify do
+            error_stubs
+
+            expect { response_instance_target_method }
+              .to change(response_instance, :connection).from(nil).to(false)
+              .and change(response_instance, :errors)
+              .from({}).to({ connection: Truemail::Validate::Smtp::Request::CONNECTION_DROPPED, helo: 'StandardError' })
+              .and change(response_instance, :helo).from(nil).to(false)
+              .and not_change(response_instance, :mailfrom)
+              .and not_change(response_instance, :rcptto)
+
+            expect(response_instance_target_method).to be(false)
+          end
+
+          include_examples 'request retry behavior'
+        end
+
+        context 'when connection other errors' do
+          let(:error_stubs) do
+            allow(session).to receive(:start).and_raise(StandardError, error_message)
+          end
+
+          specify do
+            error_stubs
+
+            expect { response_instance_target_method }
+              .to change(response_instance, :connection).from(nil).to(false)
+              .and change(response_instance, :errors)
+              .from({}).to({ connection: 'error message' })
+              .and not_change(response_instance, :helo)
+              .and not_change(response_instance, :mailfrom)
+              .and not_change(response_instance, :rcptto)
+
+            expect(response_instance_target_method).to be(false)
+          end
+
+          include_examples 'request retry behavior'
+        end
+
+        context 'when smtp response errors' do
+          it 'helo smtp server response timeout' do
+            allow(session).to receive(:start).and_yield(session)
+            allow(session).to receive(:helo).and_raise(Net::ReadTimeout)
+            allow(session).to receive(:mailfrom)
+            allow(session).to receive(:rcptto)
+
+            expect { response_instance_target_method }
+              .to change(response_instance, :connection).from(nil).to(true)
+              .and change(response_instance, :helo).from(nil).to(false)
+              .and change(response_instance, :errors)
+              .from({}).to({ helo: Truemail::Validate::Smtp::Request::RESPONSE_TIMEOUT_ERROR })
+              .and not_change(response_instance, :mailfrom)
+              .and not_change(response_instance, :rcptto)
+
+            expect(session).not_to have_received(:mailfrom)
+            expect(session).not_to have_received(:rcptto)
+
+            expect(response_instance_target_method).to be(false)
+          end
+
+          it 'mailfrom smtp server error' do
+            allow(session).to receive(:start).and_yield(session)
+            allow(session).to receive(:helo).and_return(true)
+            allow(session).to receive(:mailfrom).and_raise(StandardError, error_message)
+            allow(session).to receive(:rcptto)
+
+            expect { response_instance_target_method }
+              .to change(response_instance, :connection).from(nil).to(true)
+              .and change(response_instance, :helo).from(nil).to(true)
+              .and change(response_instance, :mailfrom).from(nil).to(false)
+              .and change(response_instance, :errors).from({}).to({ mailfrom: error_message })
+              .and not_change(response_instance, :rcptto)
+
+            expect(session).not_to have_received(:rcptto)
+
+            expect(response_instance_target_method).to be(false)
+          end
+
+          it 'rcptto smtp server error' do
+            allow(session).to receive(:start).and_yield(session)
+            allow(session).to receive(:helo).and_return(true)
+            allow(session).to receive(:mailfrom).and_return(true)
+            allow(session).to receive(:rcptto).and_raise(StandardError, error_message)
+
+            expect { response_instance_target_method }
+              .to change(response_instance, :connection).from(nil).to(true)
+              .and change(response_instance, :helo).from(nil).to(true)
+              .and change(response_instance, :mailfrom).from(nil).to(true)
+              .and change(response_instance, :rcptto).from(nil).to(false)
+              .and change(response_instance, :errors).from({}).to({ rcptto: error_message })
+
+            expect(response_instance_target_method).to be(false)
+          end
+        end
+      end
+    end
+  end
+
+  RSpec.describe Truemail::Validate::Smtp::Request::Configuration do
+    subject(:request_configuration_instance) { described_class.new(configuration_instance) }
+
+    let(:configuration_instance) { create_configuration }
+
+    describe 'defined constants' do
+      specify { expect(described_class).to be_const_defined(:REQUEST_PARAMS) }
+    end
+
+    describe 'attribute readers' do
+      let(:attribute_readers) { %i[connection_timeout response_timeout verifier_domain verifier_email] }
+
+      specify { expect(request_configuration_instance.public_methods).to include(*attribute_readers) }
+    end
+
+    describe '.new' do
+      Truemail::Validate::Smtp::Request::Configuration::REQUEST_PARAMS.each do |method|
+        specify do
+          expect(request_configuration_instance.public_send(method)).to eq(configuration_instance.public_send(method))
         end
       end
     end

--- a/spec/truemail/wrapper_spec.rb
+++ b/spec/truemail/wrapper_spec.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe Truemail::Wrapper do
-  let(:email) { FFaker::Internet.email }
-  let(:method) { :hosts_from_mx_records? }
-  let(:mx_instance) { instance_double(Truemail::Validate::Mx, method => true) }
+  let(:configuration_instance) { create_configuration }
+  let(:method) { :method }
+  let(:mx_instance) { instance_double('SomeObject', method => true) }
   let(:block) { ->(_) { mx_instance.send(method) } }
 
-  before { Truemail.configure { |config| config.verifier_email = email } }
-
   describe '.call' do
+    subject(:resolver_execution_wrapper) do
+      described_class.call(configuration: configuration_instance, &block)
+    end
+
+    it 'returns wrapped block context' do
+      expect(resolver_execution_wrapper).to be(true)
+    end
+  end
+
+  describe '#call' do
     subject(:resolver_execution_wrapper) { resolver_execution_wrapper_instance.call(&block) }
 
-    let(:resolver_execution_wrapper_instance) { described_class.new }
+    let(:resolver_execution_wrapper_instance) { described_class.new(configuration_instance) }
 
     before { allow(resolver_execution_wrapper_instance).to receive(:call).and_call_original }
 

--- a/truemail.gemspec
+++ b/truemail.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |spec|
   spec.email         = ['admin@bestweb.com.ua']
 
   spec.summary       = %(truemail)
-  spec.description   = %(Configurable plain ruby email validator. Validate email by regexp, mx records and real email existence)
+  spec.description   = %(Configurable plain Ruby email validator. Verify email via Regex, DNS and SMTP. Be sure that email address exists)
+
   spec.homepage      = 'https://github.com/rubygarage/truemail'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Implement independent configuration instance

- [x] Added ability to create new `Truemail::Configuration` instance with block, updated tests
- [x] Updated `Truemail::Wrapper`, tests
- [x] Updated `Truemail::Validate::Base`
- [x] Updated `Truemail::Validator`, tests
- [x] Updated `Truemail::Validator::Result`, tests
- [x] Updated `Truemail::Validate::Regex`, tests
- [x] Updated `Truemail::Validate::Mx`, tests
- [x] Updated `Truemail::Validate::Smtp`, tests
- [x] Updated `Truemail::Validate::Smtp::Request`, tests
- [x] Added `Truemail::Validate::Smtp::Request::Configuration`, tests
- [x] Updated `Truemail::Audit::Base`
- [x] Updated `Truemail::Auditor`, tests
- [x] Updated `Truemail::Audit::Ptr`, tests
- [x] Updated `::Truemail` module, tests
- [x] Updated gem documentation
- [x] Updated wiki
- [x] Updated gem version, gem description