### PR TITLE
Allow Punycode In Domain

### DIFF
--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -18,7 +18,7 @@ module Truemail
   end
 
   module RegexConstant
-    REGEX_DOMAIN = /[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}/i
+    REGEX_DOMAIN = /(xn--)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,63}/i
     REGEX_EMAIL_PATTERN = /(?=\A.{6,255}\z)(\A([a-zA-Z0-9]+[\w|\-|\.|\+]*)@(#{REGEX_DOMAIN})\z)/
     REGEX_DOMAIN_PATTERN = /(?=\A.{4,255}\z)(\A#{REGEX_DOMAIN}\z)/
     REGEX_DOMAIN_FROM_EMAIL = /\A.+@(.+)\z/

--- a/spec/truemail/core_spec.rb
+++ b/spec/truemail/core_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe Truemail::RegexConstant do
       expect(regex_pattern.match?('1-domain.us')).to be(true)
     end
 
+    it 'allows punycode' do
+      expect(regex_pattern.match?('xn--eu8h.us')).to be(true)
+    end
+
     it 'allows nested subdomains' do
       expect(regex_pattern.match?('42.com')).to be(true)
       expect(regex_pattern.match?('42.subdomain.domain')).to be(true)


### PR DESCRIPTION
# PR Details

<!-- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Updates the `REGEX_DOMAIN` to allow puny code domains e.g.: [xn--ls8h.la](http://xn--ls8h.la)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #61

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allows punycode domains to be used as whitelisted/blacklisted domains (and probably
other places).

## How Has This Been Tested

- Updated unit tests to cover puny code
- Installed local gem into our app and verified loading domains with punycode into the blacklist doesn't break

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/rubygarage/truemail/blob/master/CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] I have run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I have run `rubocop` and `reek` to ensure the code style is valid
