### PR TITLE
Feature/Possibility to use Truemail validator instance represented as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2020-02-01
+### Added
+- Possibility to use `Truemail::Validator` instance represented as json directly
+
+### Changed
+- gem development dependencies
+- gem documentation
+
 ## [1.5.1] - 2020-01-20
 ### Changed
 - gem development dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.5.1)
+    truemail (1.6.0)
       simpleidn (~> 0.1.1)
 
 GEM
@@ -15,7 +15,7 @@ GEM
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
-    byebug (11.1.0)
+    byebug (11.1.1)
     childprocess (3.0.0)
     codeclimate-engine-rb (0.4.1)
       virtus (~> 1.0)
@@ -50,7 +50,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.7.0)
+    pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
     psych (3.1.0)
@@ -122,7 +122,7 @@ DEPENDENCIES
   ffaker (~> 2.13)
   json_matchers (~> 0.11.1)
   overcommit (~> 0.52.1)
-  pry-byebug (~> 3.7)
+  pry-byebug (~> 3.8)
   rake (~> 13.0, >= 13.0.1)
   reek (~> 5.6)
   rspec (~> 3.9)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Configurable framework agnostic plain Ruby email validator. Verify email via Reg
     - [PTR audit](#ptr-audit)
   - [Truemail helpers](#truemail-helpers)
     - [.valid?](#valid)
+    - [#as_json](#as_json)
   - [Test environment](#test-environment)
 - [Truemail family](#truemail-family)
 - [Contributing](#contributing)
@@ -928,12 +929,51 @@ Truemail.host_audit
 
 #### .valid?
 
-You can use the ```.valid?``` helper for quick validation of email address. It returns a boolean:
+You can use the `.valid?` helper for quick validation of email address. It returns a boolean:
 
 ```ruby
 # It is shortcut for Truemail.validate('email@example.com').result.valid?
 Truemail.valid?('email@example.com')
 => true
+```
+
+#### #as_json
+
+You can use `#as_json` helper for represent `Truemail::Validator` instance as json. Under the hood it uses internal json serializer [`Truemail::Log::Serializer::Json`](#json-serializer):
+
+```ruby
+Truemail.validate('nonexistent_email@bestweb.com.ua').as_json
+
+=>
+# Serialized Truemail::Validator instance
+{
+  "date": "2020-02-01 10:00:00 +0200",
+  "email": "nonexistent_email@bestweb.com.ua",
+  "validation_type": "smtp",
+  "success": false,
+  "errors": {
+    "smtp": "smtp error"
+  },
+  "smtp_debug": [
+    {
+      "mail_host": "213.180.193.89",
+      "port_opened": true,
+      "connection": true,
+      "errors": {
+        "rcptto": "550 5.7.1 No such user!\n"
+      }
+    }
+  ],
+  "configuration": {
+    "validation_type_by_domain": null,
+    "whitelist_validation": false,
+    "whitelisted_domains": null,
+    "blacklisted_domains": null,
+    "smtp_safe_check": false,
+    "email_pattern": "default gem value",
+    "smtp_error_body_pattern": "default gem value"
+  }
+}
 ```
 
 ### Test environment

--- a/lib/truemail/validator.rb
+++ b/lib/truemail/validator.rb
@@ -32,6 +32,10 @@ module Truemail
       self
     end
 
+    def as_json
+      Truemail::Log::Serializer::Json.call(self)
+    end
+
     private
 
     def select_validation_type(email, current_validation_type)

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.5.1'
+  VERSION = '1.6.0'
 end

--- a/spec/support/schemas/validator.json
+++ b/spec/support/schemas/validator.json
@@ -46,7 +46,10 @@
     },
     "success": {
       "$id": "#/properties/success",
-      "type": "boolean",
+      "type": [
+        "boolean",
+        "null"
+      ],
       "title": "The Success Schema",
       "default": false,
       "examples": [

--- a/spec/truemail/validator_spec.rb
+++ b/spec/truemail/validator_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe Truemail::Validator do
     end
   end
 
+  describe '#as_json' do
+    subject(:validator_instance_as_json) { validator_instance.as_json }
+
+    specify do
+      expect(Truemail::Log::Serializer::Json).to receive(:call).with(validator_instance).and_call_original
+      expect(validator_instance_as_json).to match_json_schema('validator')
+    end
+  end
+
   describe '#select_validation_type' do
     subject(:select_validation_type) do
       described_class.new(email, with: current_validation_type, **configuration).validation_type

--- a/truemail.gemspec
+++ b/truemail.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ffaker', '~> 2.13'
   spec.add_development_dependency 'json_matchers', '~> 0.11.1'
   spec.add_development_dependency 'overcommit', '~> 0.52.1'
-  spec.add_development_dependency 'pry-byebug', '~> 3.7'
+  spec.add_development_dependency 'pry-byebug', '~> 3.8'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'
   spec.add_development_dependency 'reek', '~> 5.6'
   spec.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
- [x] Added possibility to use Truemail validator instance represented as `json` directly
- [x] Updated changelog
- [x] Updated version
- [x] Updated development dependencies
- [x] Updated documentation

```ruby
Truemail.validate('nonexistent_email@bestweb.com.ua').as_json

=>
# Serialized Truemail::Validator instance
{
  "date": "2020-02-01 10:00:00 +0200",
  "email": "nonexistent_email@bestweb.com.ua",
  "validation_type": "smtp",
  "success": false,
  "errors": {
    "smtp": "smtp error"
  },
  "smtp_debug": [
    {
      "mail_host": "213.180.193.89",
      "port_opened": true,
      "connection": true,
      "errors": {
        "rcptto": "550 5.7.1 No such user!\n"
      }
    }
  ],
  "configuration": {
    "validation_type_by_domain": null,
    "whitelist_validation": false,
    "whitelisted_domains": null,
    "blacklisted_domains": null,
    "smtp_safe_check": false,
    "email_pattern": "default gem value",
    "smtp_error_body_pattern": "default gem value"
  }
}
```