### PR TITLE
Feature/DNS audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.8.0] - 2020.06.21
+
+## Added
+
+Separated audit features for verifier host.
+
+- `Truemail::Audit::Ip`
+- `Truemail::Audit::Dns`
+
+```ruby
+Truemail.host_audit
+
+=> #<Truemail::Auditor:0x00005580df358828
+@result=
+  #<struct Truemail::Auditor::Result
+    current_host_ip="127.0.0.1",
+    warnings={
+      :dns=>"a record of verifier domain not refers to current host ip address",
+      :ptr=>"ptr record does not reference to current verifier domain"
+    },
+    configuration=
+    #<Truemail::Configuration:0x00005615e86327a8
+      @blacklisted_domains=[],
+      @connection_attempts=2,
+      @connection_timeout=2,
+      @default_validation_type=:smtp,
+      @email_pattern=/(?=\A.{6,255}\z)(\A([\p{L}0-9]+[\w|\-|\.|\+]*)@((?i-mx:[\p{L}0-9]+([\-\.]{1}[\p{L}0-9]+)*\.[\p{L}]{2,63}))\z)/,
+      @response_timeout=2,
+      @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
+      @not_rfc_mx_lookup_flow=false,
+      @smtp_safe_check=false,
+      @validation_type_by_domain={},
+      @verifier_domain="example.com",
+      @verifier_email="verifier@example.com",
+      @whitelist_validation=false,
+      @whitelisted_domains=[]>
+```
+
+### Changed
+
+- `Truemail::Auditor`
+- `Truemail::Auditor::Result`
+- `Truemail::Audit::Base`
+- `Truemail::Audit::Ptr`
+- `Truemail::VERSION`
+- gem documentation
 
 ## [1.7.1] - 2020.05.10
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.7.1)
+    truemail (1.8.0)
       simpleidn (~> 0.1.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Configurable framework agnostic plain Ruby email validator. Verify email via Reg
     - [Available tracking events](#available-tracking-events)
   - [JSON serializer](#json-serializer)
   - [Host audit features](#host-audit-features)
+    - [IP audit](#ip-audit)
+    - [DNS audit](#dns-audit)
     - [PTR audit](#ptr-audit)
+    - [Example of using](#example-of-using)
   - [Truemail helpers](#truemail-helpers)
     - [.valid?](#valid)
     - [#as_json](#as_json)
@@ -70,6 +73,7 @@ Also Truemail gem allows performing an audit of the host in which runs.
 - Whitelist/blacklist validation layers
 - Simple SMTP debugger
 - Event logger
+- Host auditor tools (helps to detect common host problems interfering to proper email verification)
 - JSON serializer
 
 ## Requirements
@@ -951,11 +955,23 @@ Truemail::Log::Serializer::Json.call(Truemail.validate('nonexistent_email@bestwe
 
 ### Host audit features
 
-Truemail gem allows performing an audit of the host in which runs. Only PTR record audit performs for today.
+Truemail gem allows performing an audit of the host in which runs. It will help to detect common host problems interfering to proper email verification.
+
+#### IP audit
+
+Checks is current Truemail host has proper internet connection and detects current host ip address.
+
+#### DNS audit
+
+Checks is verifier domain refer to current Truemail host IP address.
 
 #### PTR audit
 
 So what is a PTR record? A PTR record, or pointer record, enables someone to perform a reverse DNS lookup. This allows them to determine your domain name based on your IP address. Because generic domain names without a PTR are often associated with spammers, incoming mail servers identify email from hosts without PTR records as spam and you can't verify yours emails qualitatively.
+
+Checks is PTR record exists for your Truemail host ip address exists and refers to current verifier domain.
+
+#### Example of using
 
 ```ruby
 Truemail.host_audit
@@ -963,6 +979,7 @@ Truemail.host_audit
 => #<Truemail::Auditor:0x00005580df358828
    @result=
      #<struct Truemail::Auditor::Result
+       current_host_ip="127.0.0.1",
        warnings={}>,
        configuration=
         #<Truemail::Configuration:0x00005615e86327a8
@@ -981,12 +998,15 @@ Truemail.host_audit
          @whitelist_validation=false,
          @whitelisted_domains=[]>
 
-# Has PTR warning
+# Has audit warnings
 => #<Truemail::Auditor:0x00005580df358828
    @result=
      #<struct Truemail::Auditor::Result
-       warnings=
-         {:ptr=>"ptr record does not reference to current verifier domain"}>,
+       current_host_ip="127.0.0.1",
+       warnings={
+         :dns=>"a record of verifier domain not refers to current host ip address",
+         :ptr=>"ptr record does not reference to current verifier domain"
+       },
        configuration=
         #<Truemail::Configuration:0x00005615e86327a8
          @blacklisted_domains=[],

--- a/lib/truemail.rb
+++ b/lib/truemail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'truemail/core'
+require_relative 'truemail/core'
 
 module Truemail
   INCOMPLETE_CONFIG = 'verifier_email is required parameter'

--- a/lib/truemail/audit/base.rb
+++ b/lib/truemail/audit/base.rb
@@ -3,10 +3,18 @@
 module Truemail
   module Audit
     class Base < Truemail::Worker
+      require 'net/http'
+      require 'ipaddr'
+      require 'resolv'
+
       private
 
       def add_warning(message)
         result.warnings[self.class.name.split('::').last.downcase.to_sym] = message
+      end
+
+      def current_host_ip
+        result.current_host_ip
       end
 
       def configuration

--- a/lib/truemail/audit/dns.rb
+++ b/lib/truemail/audit/dns.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Truemail
+  module Audit
+    class Dns < Truemail::Audit::Base
+      VERIFIER_DOMAIN_NOT_REFER = 'a record of verifier domain not refers to current host ip address'
+
+      def run
+        return if verifier_domain_refer_to_current_host_ip?
+        add_warning(Truemail::Audit::Dns::VERIFIER_DOMAIN_NOT_REFER)
+      end
+
+      private
+
+      def a_record
+        Truemail::Wrapper.call(configuration: configuration) do
+          Resolv::DNS.new.getaddress(verifier_domain).to_s
+        end
+      end
+
+      def verifier_domain_refer_to_current_host_ip?
+        a_record.eql?(current_host_ip)
+      end
+    end
+  end
+end

--- a/lib/truemail/audit/ip.rb
+++ b/lib/truemail/audit/ip.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Truemail
+  module Audit
+    class Ip < Truemail::Audit::Base
+      GET_MY_IP_URL = 'https://api.ipify.org'
+      IPIFY_ERROR = 'impossible to detect current host address via third party service'
+
+      def run
+        return add_warning(Truemail::Audit::Ip::IPIFY_ERROR) unless detect_current_host_ip
+        Truemail::Audit::Dns.check(result)
+        Truemail::Audit::Ptr.check(result)
+      end
+
+      private
+
+      def detect_ip_via_ipify
+        Net::HTTP.get(URI(Truemail::Audit::Ip::GET_MY_IP_URL))
+      end
+
+      def detect_current_host_ip
+        result.current_host_ip = Truemail::Wrapper.call(configuration: configuration) do
+          detect_ip_via_ipify
+        end
+      end
+    end
+  end
+end

--- a/lib/truemail/audit/ptr.rb
+++ b/lib/truemail/audit/ptr.rb
@@ -3,38 +3,19 @@
 module Truemail
   module Audit
     class Ptr < Truemail::Audit::Base
-      require 'net/http'
-      require 'ipaddr'
-      require 'resolv'
-
-      GET_MY_IP_URL = 'https://api.ipify.org'
-      IPIFY_ERROR = 'impossible to detect current host address via third party service'
-      PTR_NOT_FOUND = 'ptr record for current host address was not found'
+      PTR_NOT_FOUND = 'ptr record for current host ip address was not found'
       PTR_NOT_REFER = 'ptr record does not reference to current verifier domain'
-      VERIFIER_DOMAIN_NOT_REFER = 'a record of verifier domain not refers to current host address'
 
       def run
-        return if !current_host_address && add_warning(Truemail::Audit::Ptr::IPIFY_ERROR)
-        return if ptr_records.empty? && add_warning(Truemail::Audit::Ptr::PTR_NOT_FOUND)
-        return if ptr_not_refer_to_verifier_domain? && add_warning(Truemail::Audit::Ptr::PTR_NOT_REFER)
-        return if verifier_domain_refer_to_current_host_address?
-        add_warning(Truemail::Audit::Ptr::VERIFIER_DOMAIN_NOT_REFER)
+        return add_warning(Truemail::Audit::Ptr::PTR_NOT_FOUND) if ptr_records.empty?
+        return if ptr_refer_to_verifier_domain?
+        add_warning(Truemail::Audit::Ptr::PTR_NOT_REFER)
       end
 
       private
 
-      def detect_ip_via_ipify
-        Net::HTTP.get(URI(Truemail::Audit::Ptr::GET_MY_IP_URL))
-      end
-
-      def current_host_address
-        @current_host_address ||= Truemail::Wrapper.call(configuration: configuration) do
-          IPAddr.new(detect_ip_via_ipify)
-        end
-      end
-
       def current_host_reverse_lookup
-        current_host_address.reverse
+        IPAddr.new(current_host_ip).reverse
       end
 
       def ptr_records
@@ -45,18 +26,8 @@ module Truemail
         end || []
       end
 
-      def ptr_not_refer_to_verifier_domain?
-        !ptr_records.include?(verifier_domain)
-      end
-
-      def a_record
-        Truemail::Wrapper.call(configuration: configuration) do
-          Resolv::DNS.new.getaddress(verifier_domain).to_s
-        end
-      end
-
-      def verifier_domain_refer_to_current_host_address?
-        a_record.eql?(current_host_address.to_s)
+      def ptr_refer_to_verifier_domain?
+        ptr_records.include?(verifier_domain)
       end
     end
   end

--- a/lib/truemail/auditor.rb
+++ b/lib/truemail/auditor.rb
@@ -2,7 +2,7 @@
 
 module Truemail
   class Auditor
-    Result = Struct.new(:warnings, :configuration, keyword_init: true) do
+    Result = Struct.new(:current_host_ip, :warnings, :configuration, keyword_init: true) do
       def initialize(warnings: {}, **args)
         super
       end
@@ -15,7 +15,7 @@ module Truemail
     end
 
     def run
-      Truemail::Audit::Ptr.check(result)
+      Truemail::Audit::Ip.check(result)
       self
     end
   end

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Truemail
-  require 'truemail/version'
-  require 'truemail/configuration'
-  require 'truemail/worker'
-  require 'truemail/wrapper'
-  require 'truemail/auditor'
-  require 'truemail/validator'
-  require 'truemail/logger'
+  require_relative '../truemail/version'
+  require_relative '../truemail/configuration'
+  require_relative '../truemail/worker'
+  require_relative '../truemail/wrapper'
+  require_relative '../truemail/auditor'
+  require_relative '../truemail/validator'
+  require_relative '../truemail/logger'
 
   ConfigurationError = Class.new(StandardError)
 
@@ -37,24 +37,26 @@ module Truemail
   end
 
   module Audit
-    require 'truemail/audit/base'
-    require 'truemail/audit/ptr'
+    require_relative '../truemail/audit/base'
+    require_relative '../truemail/audit/ip'
+    require_relative '../truemail/audit/dns'
+    require_relative '../truemail/audit/ptr'
   end
 
   module Validate
-    require 'truemail/validate/base'
-    require 'truemail/validate/domain_list_match'
-    require 'truemail/validate/regex'
-    require 'truemail/validate/mx'
-    require 'truemail/validate/smtp'
-    require 'truemail/validate/smtp/response'
-    require 'truemail/validate/smtp/request'
+    require_relative '../truemail/validate/base'
+    require_relative '../truemail/validate/domain_list_match'
+    require_relative '../truemail/validate/regex'
+    require_relative '../truemail/validate/mx'
+    require_relative '../truemail/validate/smtp'
+    require_relative '../truemail/validate/smtp/response'
+    require_relative '../truemail/validate/smtp/request'
   end
 
   module Log
-    require 'truemail/log/event'
-    require 'truemail/log/serializer/base'
-    require 'truemail/log/serializer/text'
-    require 'truemail/log/serializer/json'
+    require_relative '../truemail/log/event'
+    require_relative '../truemail/log/serializer/base'
+    require_relative '../truemail/log/serializer/text'
+    require_relative '../truemail/log/serializer/json'
   end
 end

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.7.1'
+  VERSION = '1.8.0'
 end

--- a/spec/truemail/audit/dns_spec.rb
+++ b/spec/truemail/audit/dns_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe Truemail::Audit::Dns do
+  let(:configuration_instance) { create_configuration }
+  let(:result_instance) { Truemail::Auditor::Result.new(configuration: configuration_instance) }
+
+  describe 'defined constants' do
+    specify { expect(described_class).to be_const_defined(:VERIFIER_DOMAIN_NOT_REFER) }
+  end
+
+  describe 'inheritance' do
+    specify { expect(described_class).to be < Truemail::Audit::Base }
+  end
+
+  describe '.check' do
+    subject(:dns_auditor) { described_class.check(result_instance) }
+
+    let(:dns_auditor_instance) { instance_double(described_class) }
+
+    it 'receive #run' do
+      allow(described_class).to receive(:new).and_return(dns_auditor_instance)
+      expect(dns_auditor_instance).to receive(:run)
+      dns_auditor
+    end
+  end
+
+  describe '#run' do
+    subject(:dns_auditor) { dns_auditor_instance.run }
+
+    let(:dns_auditor_instance) { described_class.new(result_instance) }
+
+    describe 'Success' do
+      context 'when a record found and refers to current host ip' do
+        it 'not changes warnings' do
+          allow(dns_auditor_instance).to receive(:verifier_domain_refer_to_current_host_ip?).and_return(true)
+          expect { dns_auditor }.to not_change(result_instance, :warnings)
+          dns_auditor
+        end
+      end
+    end
+
+    describe 'Fails' do
+      shared_examples 'addes verifier domain not refer warning to result instance' do
+        it 'addes verifier domain not refer warning to result instance' do
+          expectation
+          expect { dns_auditor }
+            .to change(result_instance, :warnings)
+            .from({}).to(dns: Truemail::Audit::Dns::VERIFIER_DOMAIN_NOT_REFER)
+          dns_auditor
+        end
+      end
+
+      context 'when verifier domain not found' do
+        let(:expectation) { allow(dns_auditor_instance).to receive(:a_record).and_return(false) }
+
+        include_examples 'addes verifier domain not refer warning to result instance'
+      end
+
+      context 'when a record of verifier domain not refers to currernt host ip address' do
+        let(:expectation) do
+          allow(dns_auditor_instance).to receive(:verifier_domain_refer_to_current_host_ip?).and_return(false)
+        end
+
+        include_examples 'addes verifier domain not refer warning to result instance'
+      end
+    end
+  end
+end

--- a/spec/truemail/audit/ip_spec.rb
+++ b/spec/truemail/audit/ip_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe Truemail::Audit::Ip do
+  let(:configuration_instance) { create_configuration }
+  let(:result_instance) { Truemail::Auditor::Result.new(configuration: configuration_instance) }
+
+  describe 'defined constants' do
+    specify { expect(described_class).to be_const_defined(:GET_MY_IP_URL) }
+    specify { expect(described_class).to be_const_defined(:IPIFY_ERROR) }
+  end
+
+  describe 'inheritance' do
+    specify { expect(described_class).to be < Truemail::Audit::Base }
+  end
+
+  describe '.check' do
+    subject(:ip_auditor) { described_class.check(result_instance) }
+
+    let(:chain_of_audit_checks) { :chain_of_audit_checks }
+    let(:ip_auditor_instance) { instance_double(described_class, run: chain_of_audit_checks) }
+
+    it 'receive #run' do
+      allow(described_class).to receive(:new).and_return(ip_auditor_instance)
+      expect(ip_auditor_instance).to receive(:run)
+      expect(ip_auditor).to eq(chain_of_audit_checks)
+    end
+  end
+
+  describe '#run' do
+    subject(:ip_auditor) { ip_auditor_instance.run }
+
+    let(:ip_auditor_instance) { described_class.new(result_instance) }
+
+    describe 'Success' do
+      context 'when determination of host ip address was successful' do
+        let(:host_address) { FFaker::Internet.ip_v4_address }
+
+        it 'save host address to result, not changes warnings' do
+          expect(ip_auditor_instance).to receive(:detect_ip_via_ipify).and_return(host_address)
+          expect(Truemail::Audit::Dns).to receive(:check).with(result_instance)
+          expect(Truemail::Audit::Ptr).to receive(:check).with(result_instance)
+          expect { ip_auditor }
+            .to change(result_instance, :current_host_ip)
+            .from(nil)
+            .to(host_address)
+            .and not_change(result_instance, :warnings)
+        end
+
+        it 'not sensitive to the audit result, runs all possible audit checks' do
+          expect(ip_auditor_instance).to receive(:detect_ip_via_ipify).and_return(host_address)
+          expect(Truemail::Audit::Dns).to receive(:check).with(result_instance).and_return(false)
+          expect(Truemail::Audit::Ptr).to receive(:check).with(result_instance)
+          ip_auditor
+        end
+      end
+    end
+
+    describe 'Fails' do
+      shared_examples 'addes ipify warning to result instance' do
+        it 'addes ipify warning to result instance' do
+          expectation
+          expect(Truemail::Audit::Dns).not_to receive(:check).with(result_instance)
+          expect(Truemail::Audit::Ptr).not_to receive(:check).with(result_instance)
+          expect { ip_auditor }.to change(result_instance, :warnings).from({}).to(ip: Truemail::Audit::Ip::IPIFY_ERROR)
+        end
+      end
+
+      context 'if error with third party service' do
+        let(:expectation) { expect(Truemail::Wrapper).to receive(:call).and_return(false) }
+
+        include_examples 'addes ipify warning to result instance'
+      end
+
+      context 'if network error' do
+        let(:expectation) { expect(ip_auditor_instance).to receive(:detect_ip_via_ipify).and_raise(IPAddr::InvalidAddressError) }
+
+        include_examples 'addes ipify warning to result instance'
+      end
+    end
+  end
+
+  describe 'ipify third party service integration tests' do
+    context 'when calles #detect_ip_via_ipify' do
+      subject(:ipify_response) { ip_auditor_instance.send(:detect_ip_via_ipify) }
+
+      let(:ip_auditor_instance) { described_class.new(result_instance) }
+
+      it 'returns current host ip address as a string' do
+        expect(ipify_response).to be_an_instance_of(String)
+      end
+
+      it 'returned string matches to ip address pattern' do
+        expect(ipify_response).to match_to_ip_address
+      end
+    end
+  end
+end

--- a/spec/truemail/audit/ptr_spec.rb
+++ b/spec/truemail/audit/ptr_spec.rb
@@ -5,11 +5,8 @@ RSpec.describe Truemail::Audit::Ptr do
   let(:result_instance) { Truemail::Auditor::Result.new(configuration: configuration_instance) }
 
   describe 'defined constants' do
-    specify { expect(described_class).to be_const_defined(:GET_MY_IP_URL) }
-    specify { expect(described_class).to be_const_defined(:IPIFY_ERROR) }
     specify { expect(described_class).to be_const_defined(:PTR_NOT_FOUND) }
     specify { expect(described_class).to be_const_defined(:PTR_NOT_REFER) }
-    specify { expect(described_class).to be_const_defined(:VERIFIER_DOMAIN_NOT_REFER) }
   end
 
   describe 'inheritance' do
@@ -24,7 +21,7 @@ RSpec.describe Truemail::Audit::Ptr do
     it 'receive #run' do
       allow(described_class).to receive(:new).and_return(ptr_auditor_instance)
       expect(ptr_auditor_instance).to receive(:run)
-      expect(ptr_auditor).to be(true)
+      ptr_auditor
     end
   end
 
@@ -33,119 +30,45 @@ RSpec.describe Truemail::Audit::Ptr do
 
     let(:ptr_auditor_instance) { described_class.new(result_instance) }
     let(:host_name) { configuration_instance.verifier_domain }
-    let(:host_address) { FFaker::Internet.ip_v4_address }
-    let(:other_host_address) { '127.0.0.1' }
+    let(:other_host_name) { 'other_host_name' }
 
     describe 'Success' do
-      context 'when ptr record exists, refereces to verifier domain and has reverse trace' do
-        before do
-          allow(ptr_auditor_instance).to receive(:detect_ip_via_ipify).and_return(host_address)
-          allow(ptr_auditor_instance).to receive(:ptr_records).and_return([host_name])
-          allow(ptr_auditor_instance).to receive(:a_record).and_return(host_address)
-        end
-
+      context 'when ptr record exists and refereces to verifier domain' do
         it 'not changes warnings' do
+          allow(ptr_auditor_instance).to receive(:ptr_records).and_return([host_name])
           expect { ptr_auditor }.to not_change(result_instance, :warnings)
         end
       end
     end
 
     describe 'Fails' do
-      context 'when determining current host address' do
-        let(:expectation) do
-          expect { ptr_auditor }.to change(result_instance, :warnings).from({}).to(ptr: Truemail::Audit::Ptr::IPIFY_ERROR)
-        end
-
-        context 'if error with third party service' do
-          it 'addes ipify warning' do
-            expect(ptr_auditor_instance).to receive(:current_host_address).and_return(false)
-            expectation
-          end
-        end
-
-        context 'if network error' do
-          it 'addes ipify warning' do
-            expect(ptr_auditor_instance).to receive(:detect_ip_via_ipify).and_raise(IPAddr::InvalidAddressError)
-            expectation
-          end
-        end
-      end
-
       context 'when determining ptr records' do
         let(:expectation) do
           expect { ptr_auditor }.to change(result_instance, :warnings).from({}).to(ptr: Truemail::Audit::Ptr::PTR_NOT_FOUND)
         end
 
-        context 'if ptr record for current host address was not found' do
+        context 'when ptr record checking crashes' do
           it 'addes not found warning' do
-            expect(ptr_auditor_instance).to receive(:current_host_address).and_return(true)
-            expect(ptr_auditor_instance).to receive(:ptr_records).and_return([])
+            expect(Truemail::Wrapper).to receive(:call).and_return(false)
             expectation
           end
         end
 
-        context 'if ptr record checking crashes' do
+        context 'when ptr record for current host address was not found' do
           it 'addes not found warning' do
-            expect(ptr_auditor_instance).to receive(:current_host_address).and_return(true)
-            expect(ptr_auditor_instance).to receive(:current_host_reverse_lookup).and_raise(Resolv::ResolvError)
+            expect(ptr_auditor_instance).to receive(:ptr_records).and_return([])
             expectation
           end
         end
       end
 
       context 'when determining ptr referer' do
-        context 'if ptr records do not refer to verifier domain' do
+        context 'when ptr records do not refer to verifier domain' do
           it 'addes not references warning' do
-            expect(ptr_auditor_instance).to receive(:current_host_address).and_return(true)
-            expect(ptr_auditor_instance).to receive(:ptr_records).and_return([host_name])
-            expect(ptr_auditor_instance).to receive(:ptr_not_refer_to_verifier_domain?).and_return(true)
+            allow(ptr_auditor_instance).to receive(:ptr_records).and_return([other_host_name])
             expect { ptr_auditor }.to change(result_instance, :warnings).from({}).to(ptr: Truemail::Audit::Ptr::PTR_NOT_REFER)
           end
         end
-      end
-
-      context 'when determining verifier domain referer' do
-        let(:expectation) do
-          expect { ptr_auditor }
-            .to change(result_instance, :warnings)
-            .from({}).to(ptr: Truemail::Audit::Ptr::VERIFIER_DOMAIN_NOT_REFER)
-        end
-
-        before do
-          allow(ptr_auditor_instance).to receive(:detect_ip_via_ipify).and_return(host_address)
-          allow(ptr_auditor_instance).to receive(:ptr_records).and_return([host_name])
-          allow(ptr_auditor_instance).to receive(:ptr_not_refer_to_verifier_domain?).and_return(false)
-        end
-
-        context 'if verifier domain a record does not refer to ptr record' do
-          it 'addes not reverse trace warning' do
-            expect(ptr_auditor_instance).to receive(:a_record).and_return(other_host_address)
-            expectation
-          end
-        end
-
-        context 'if network error' do
-          it 'addes not reverse trace warning' do
-            expect(Resolv::DNS).to receive_message_chain(:new, :getaddress, :to_s).and_raise(Resolv::ResolvError)
-            expectation
-          end
-        end
-      end
-    end
-  end
-
-  describe 'ipify third party service integration tests' do
-    context 'when calles #detect_ip_via_ipify' do
-      subject(:ipify_response) { ptr_auditor_instance.send(:detect_ip_via_ipify) }
-
-      let(:ptr_auditor_instance) { described_class.new(result_instance) }
-
-      it 'returns current host ip address as a string' do
-        expect(ipify_response).to be_an_instance_of(String)
-      end
-
-      it 'returned string matches to ip address pattern' do
-        expect(ipify_response).to match_to_ip_address
       end
     end
   end

--- a/spec/truemail/auditor_spec.rb
+++ b/spec/truemail/auditor_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Truemail::Auditor do
 
   describe '#run' do
     it 'runs audition methods' do
-      expect(Truemail::Audit::Ptr).to receive(:check)
+      expect(Truemail::Audit::Ip).to receive(:check)
       expect(auditor_instance.run).to be_an_instance_of(described_class)
     end
   end
@@ -27,10 +27,10 @@ RSpec.describe Truemail::Auditor::Result do
   subject(:result_instance) { described_class.new }
 
   it 'has attribute accessors warnings, configuration' do
-    expect(result_instance.members).to include(:warnings, :configuration)
+    expect(result_instance.members).to match_array(%i[current_host_ip warnings configuration])
   end
 
-  it 'has default values for attributes' do
+  it 'has default value for warnings attribute' do
     expect(result_instance.warnings).to eq({})
   end
 

--- a/spec/truemail/validator_spec.rb
+++ b/spec/truemail/validator_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Truemail::Validator::Result do
   let(:email) { FFaker::Internet.email }
 
   specify do
-    expect(result_instance.members).to include(*Truemail::Validator::RESULT_ATTRS)
+    expect(result_instance.members).to match_array(Truemail::Validator::RESULT_ATTRS)
   end
 
   it 'has .valid? alias' do

--- a/spec/truemail_spec.rb
+++ b/spec/truemail_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Truemail do
       it 'returns auditor instance' do
         expect(Truemail::Auditor).to receive(:new).and_call_original
         expect_any_instance_of(Truemail::Auditor).to receive(:run).and_call_original
-        expect(Truemail::Audit::Ptr).to receive(:check).and_return(true)
+        expect(Truemail::Audit::Ip).to receive(:check).and_return(true)
         expect(host_audit).to be_an_instance_of(Truemail::Auditor)
       end
     end


### PR DESCRIPTION
**Separated audit features for Truemail verifier host.**

- [x] Implement separated DNS audit for verifier host
- [x] Refactored `Truemail::Auditor`, `Truemail::Audit::Base`, `Truemail::Auditor::Result`
- [x] Extracted IP determining logic to independet auditor class
- [x] Refactored PTR audit logic
- [x] Updated documentation, changelog

```ruby
Truemail.host_audit

=> #<Truemail::Auditor:0x00005580df358828
@result=
  #<struct Truemail::Auditor::Result
    current_host_ip="127.0.0.1",
    warnings={
      :dns=>"a record of verifier domain not refers to current host ip address",
      :ptr=>"ptr record does not reference to current verifier domain"
    },
    configuration=
    #<Truemail::Configuration:0x00005615e86327a8
      @blacklisted_domains=[],
      @connection_attempts=2,
      @connection_timeout=2,
      @default_validation_type=:smtp,
      @email_pattern=/(?=\A.{6,255}\z)(\A([\p{L}0-9]+[\w|\-|\.|\+]*)@((?i-mx:[\p{L}0-9]+([\-\.]{1}[\p{L}0-9]+)*\.[\p{L}]{2,63}))\z)/,
      @response_timeout=2,
      @smtp_error_body_pattern=/(?=.*550)(?=.*(user|account|customer|mailbox)).*/i,
      @not_rfc_mx_lookup_flow=false,
      @smtp_safe_check=false,
      @validation_type_by_domain={},
      @verifier_domain="example.com",
      @verifier_email="verifier@example.com",
      @whitelist_validation=false,
      @whitelisted_domains=[]>
```