### PR TITLE
Feature/Add input email type checking, #93

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - [ ] I have updated truemail to the latest version
 - [ ] I have read the [Contribution Guidelines](https://github.com/rubygarage/truemail/blob/master/CONTRIBUTING.md)
-- [ ] I have read the [documentation](https://github.com/rubygarage/truemail/blob/master/README.md)
+- [ ] I have read the [documentation](https://truemail-rb.org/truemail-gem)
 - [ ] I have searched for [existing GitHub issues](https://github.com/rubygarage/truemail/issues)
 
 ### Issue Description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2020.10.02
+
+### Added
+
+- `Truemail::TypeError`
+- error handling for invalid types as input email
+
+### Changed
+
+- Updated `Truemail.validate`
+- Updated `Truemail.valid?`
+
 ## [1.9.1] - 2020.09.21
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truemail (1.9.1)
+    truemail (1.9.2)
       simpleidn (~> 0.1.1)
 
 GEM

--- a/lib/truemail.rb
+++ b/lib/truemail.rb
@@ -5,6 +5,7 @@ require_relative 'truemail/core'
 module Truemail
   INCOMPLETE_CONFIG = 'verifier_email is required parameter'
   NOT_CONFIGURED = 'use Truemail.configure before or pass custom configuration'
+  INVALID_TYPE = 'email should be a String'
 
   class << self
     def configuration(&block)
@@ -25,10 +26,12 @@ module Truemail
     end
 
     def validate(email, custom_configuration: nil, **options)
+      check_argument_type(email)
       Truemail::Validator.new(email, configuration: determine_configuration(custom_configuration), **options).run
     end
 
     def valid?(email, **options)
+      check_argument_type(email)
       validate(email, **options).result.valid?
     end
 
@@ -38,8 +41,12 @@ module Truemail
 
     private
 
-    def raise_unless(condition, message)
-      raise Truemail::ConfigurationError, message unless condition
+    def raise_unless(condition, message, error_class = Truemail::ConfigurationError)
+      raise error_class, message unless condition
+    end
+
+    def check_argument_type(argument)
+      raise_unless(argument.is_a?(String), Truemail::INVALID_TYPE, Truemail::TypeError)
     end
 
     def determine_configuration(custom_configuration)

--- a/lib/truemail/core.rb
+++ b/lib/truemail/core.rb
@@ -11,6 +11,7 @@ module Truemail
   require_relative '../truemail/logger'
 
   ConfigurationError = Class.new(StandardError)
+  TypeError = Class.new(StandardError)
 
   ArgumentError = Class.new(StandardError) do
     def initialize(arg_value, arg_name)

--- a/lib/truemail/version.rb
+++ b/lib/truemail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truemail
-  VERSION = '1.9.1'
+  VERSION = '1.9.2'
 end


### PR DESCRIPTION
Added error handling for invalid types as input email.

- [x] Added `Truemail::TypeError`
- [x] Updated `Truemail.validate`
- [x] Updated `Truemail.valid?`